### PR TITLE
Convert UInt_t to Long_t before taking difference and abs. Fixes #34.

### DIFF
--- a/Analysis/src/QwF1TDContainer.cc
+++ b/Analysis/src/QwF1TDContainer.cc
@@ -1609,7 +1609,7 @@ QwF1TDContainer::CheckDataIntegrity(const ROCID_t roc_id, UInt_t *buffer, UInt_t
 	    xor_setup_flag    = fF1TDCDecoder.IsHeaderXorSetup();
 	    trig_fifo_ok_flag = fF1TDCDecoder.IsNotHeaderTrigFIFO();
 	    event_ok_flag     = ( reference_event_num==fF1TDCDecoder.GetTDCHeaderEventNumber() );
-	    diff_trigger_time = abs( reference_trig_time-fF1TDCDecoder.GetTDCHeaderTriggerTime() );
+	    diff_trigger_time = abs( Long_t(reference_trig_time) - Long_t(fF1TDCDecoder.GetTDCHeaderTriggerTime()) );
 
 	    trig_time_ok_flag = 
 	      (diff_trigger_time == valid_trigger_time_offset[0])  


### PR DESCRIPTION
Since both reference_trig_time and fF1TDCDecoder.GetTDCHeaderTriggerTime()
return a UInt_t and taking the difference is going to return a UInt_t as
well, we should convert to Long_t first. Then the std::abs is well defined
and doesn't fail to compile on gcc-8.