### PR TITLE
#include <cmath> is preferred over #include <math.h> in C++.

### DIFF
--- a/Analysis/include/QwF1TDContainer.h
+++ b/Analysis/include/QwF1TDContainer.h
@@ -8,7 +8,7 @@
  */
 
 #include <iostream>
-#include <math.h>
+#include <cmath>
 
 
 #include "QwTypes.h"

--- a/Analysis/src/MQwF1TDC.cc
+++ b/Analysis/src/MQwF1TDC.cc
@@ -10,7 +10,7 @@
 #include "QwColor.h"
 #include "QwLog.h"
 
-#include <math.h>
+#include <cmath>
 
 
 const UInt_t MQwF1TDC::kF1Mask_SlotNumber           = 0xf8000000;

--- a/Analysis/src/QwEPICSEvent.cc
+++ b/Analysis/src/QwEPICSEvent.cc
@@ -3,7 +3,7 @@
 // System headers
 #include <iostream>
 #include <fstream>
-#include <math.h>
+#include <cmath>
 
 // ROOT headers
 #include "TObject.h"


### PR DESCRIPTION
The old math.h header uses C syntax which imports the functions
in the global namespace (rather, C does not have namespaces, so
any C headers included in a C++ program will end up in global
namespace). By using the C++ header cmath, the functions will
be loaded in the std namespace.