### PR TITLE
Feature: RPATH for installed binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ file(GLOB my_evio_sources
 find_package(ROOT REQUIRED)
 include_directories(${ROOT_INCLUDE_DIR})
 set(ROOT_LIBRARIES ${ROOT_LIBRARIES} -lNew -lGui -lMinuit2)
+list(APPEND CMAKE_INSTALL_RPATH ${ROOT_LIBRARY_DIR})
 
 # Load MYSQLPP
 find_package(MYSQLPP)
@@ -104,6 +105,7 @@ IF(MYSQLPP_FOUND)
   #    )
   message("--   Forcing MYSQLPP_LIBRARIES to \"\".")
   SET(MYSQLPP_LIBRARIES "")
+  list(APPEND CMAKE_INSTALL_RPATH ${MYSQLPP_LIBRARY_DIR})
 ELSE(MYSQLPP_FOUND)
   SET(MYSQLPP_LIBRARIES "")
 endif(MYSQLPP_FOUND)
@@ -115,6 +117,7 @@ SET( Boost_NO_BOOST_CMAKE ON )
 find_package(Boost COMPONENTS program_options filesystem system regex REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIR})
+list(APPEND CMAKE_INSTALL_RPATH ${Boost_LIBRARY_DIRS})
 
 # Find the CODA ET libaries
 find_package(ET)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,20 +31,17 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/evio/include
   ${CMAKE_CURRENT_SOURCE_DIR}/Parity/include
   ${CMAKE_CURRENT_SOURCE_DIR}/Analysis/include
-  ${CMAKE_CURRENT_SOURCE_DIR}/Tracking/include
   )
 
 # Put all QwAnalysis files in my_project_sources
 file(GLOB my_project_headers
   ${CMAKE_CURRENT_SOURCE_DIR}/Analysis/include/*.h
   ${CMAKE_CURRENT_SOURCE_DIR}/Parity/include/*.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/Tracking/include/*.h
   ${CMAKE_CURRENT_BINARY_DIR}/include/QwSVNVersion.h
   )
 file(GLOB my_project_sources
   ###  ${CMAKE_CURRENT_SOURCE_DIR}/Analysis/src/*.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/Parity/src/*.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/Tracking/src/*.cc
   )
 list(APPEND my_project_sources
   ${CMAKE_CURRENT_SOURCE_DIR}/Analysis/src/MQwCodaControlEvent.cc
@@ -222,7 +219,6 @@ install(FILES ${pcmfiles} DESTINATION ${CMAKE_SOURCE_DIR}/lib)
 file(GLOB exefiles
   ${CMAKE_SOURCE_DIR}/Parity/main/*.cc
   ${CMAKE_SOURCE_DIR}/Analysis/main/*.cc
-  ${CMAKE_SOURCE_DIR}/Tracking/main/*.cc
   )
 foreach(file ${exefiles})
   get_filename_component(filename ${file} NAME_WE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,12 +111,9 @@ ELSE(MYSQLPP_FOUND)
 endif(MYSQLPP_FOUND)
 
 # Find Boost libraries
-# There seems to be a bug starting in version 2.8.4 of CMake's boost
-# finding process. As such, we'll disable it here and require 2.8.4 or higher
-SET( Boost_NO_BOOST_CMAKE ON )
 find_package(Boost COMPONENTS program_options filesystem system regex REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
-link_directories(${Boost_LIBRARY_DIR})
+link_directories(${Boost_LIBRARY_DIRS})
 list(APPEND CMAKE_INSTALL_RPATH ${Boost_LIBRARY_DIRS})
 
 # Find the CODA ET libaries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,12 @@ cmake_minimum_required(VERSION 2.8.4 FATAL_ERROR)
 # Name of this project
 project(QwAnalysis)
 
-#  Install in the 
-set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR})
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+# Default install path is the source directory
+if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    message(STATUS "    Install-prefix was at default -> forcing it to the source-dir" )
+    message(STATUS "    Use -DCMAKE_INSTALL_PREFIX=/usr/local to set to something else" )
+    set (CMAKE_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}")
+endif()
 
 message(STATUS "System name ${CMAKE_SYSTEM_NAME}")
 #MAC specific variable
@@ -200,6 +203,9 @@ set_property(
   SOURCE ${CMAKE_SOURCE_DIR}/Analysis/src/QwOptions.cc ${CMAKE_SOURCE_DIR}/Analysis/src/QwRunCondition.cc
   APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/include/gitinfo.hh
   )
+
+# Set rpath
+list(APPEND CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 
 # Link the evio library
 add_library(evio SHARED ${my_evio_sources})


### PR DESCRIPTION
This will require testing on a system where rpaths actually make a difference, like adaq or apar. I don't have access to that right now. I'll see if I can rig up something on the farm... but some of you may have the systems in place already.

I'm interested in looking at what the following returns in followup bug reports:
```
chrpath -l lib/libQwAnalysis.so
chrpath -l bin/qwparity
```
