### PR TITLE
Use string literal gitinfo instead of hex-encoded version

### DIFF
--- a/Analysis/src/QwOptions.cc
+++ b/Analysis/src/QwOptions.cc
@@ -319,7 +319,7 @@ void QwOptions::Version()
 #endif
 
   QwMessage << "\n Qweak Analysis Framework : " << fArgv[0] << QwLog::endl;
-  QwMessage << " * GIT info: " << gGitInfoStr << QwLog::endl;
+  QwMessage << " * GIT info: " << gGitInfo << QwLog::endl;
   //  QwMessage << " * Revision: " << QWANA_SVN_REVISION << QwLog::endl;
   //  QwMessage << " * URL: " << QWANA_SVN_URL << QwLog::endl;
   //  QwMessage << " * Last Changed Rev: " << QWANA_SVN_LASTCHANGEDREVISION << QwLog::endl;

--- a/Analysis/src/QwRunCondition.cc
+++ b/Analysis/src/QwRunCondition.cc
@@ -41,7 +41,7 @@ QwRunCondition::SetArgs(Int_t argc, Char_t* argv[])
 #if ROOT_VERSION_CODE < ROOT_VERSION(6,0,0)
   root_version += ", SVN : ";
   root_version += gROOT->GetSvnRevision();
-  root_version += " ";   
+  root_version += " ";
   root_version += gROOT->GetSvnBranch();
 #else // ROOT_VERSION_CODE >= ROOT_VERSION(6,0,0)
   root_version += ", GIT : ";
@@ -69,11 +69,6 @@ QwRunCondition::SetArgs(Int_t argc, Char_t* argv[])
   TTimeStamp time_stamp;
   TString current_time = time_stamp.AsString("l"); // local time
 
-  // source code information ~ git
-  char gitInfo[__GITMAXINFO_SIZE];
-  gitInfo[0]='\0';
-  strcpy(gitInfo,gGitInfoStr);
-
   // get current ROC flags 
   TString roc_flags;
   // if one of the cdaq cluster AND the user must be a "cdaq", 
@@ -83,7 +78,6 @@ QwRunCondition::SetArgs(Int_t argc, Char_t* argv[])
   else {
     roc_flags = "Invalid, because the system is not cdaqlx and the user is not cdaq.";
   }
-    
 
   // insert some comments at the beginning of strings...
   root_version.Insert   (0, "ROOT Version : ");
@@ -104,7 +98,7 @@ QwRunCondition::SetArgs(Int_t argc, Char_t* argv[])
   this -> Add(user_name);
   this -> Add(argv_list);
   this -> Add(current_time);
-  this -> Add(gitInfo);
+  this -> Add(gGitInfo);
   this -> Add(roc_flags);
 
   return;

--- a/Parity/src/LRBCorrector.cc
+++ b/Parity/src/LRBCorrector.cc
@@ -115,7 +115,7 @@ Int_t LRBCorrector::LoadChannelMap(const std::string& mapfile) {
   //    Loop over # of dep variables
   //      Push-back the sensitiivity, IV type and IVnames into their respective vectors for each DV
 
-  for (size_t i = 0; i < dvnames->GetXaxis()->GetNbins(); ++i){
+  for (Int_t i = 0; i < dvnames->GetXaxis()->GetNbins(); ++i){
     type_name_dv = ParseRegressionVariable(dvnames->GetXaxis()->GetBinLabel(i+1));
     fDependentType.push_back(type_name_dv.first);
     fDependentName.push_back(type_name_dv.second);
@@ -123,11 +123,11 @@ Int_t LRBCorrector::LoadChannelMap(const std::string& mapfile) {
 
   fSensitivity.resize(fDependentType.size());
 
-  for (size_t i = 0; i < ivnames->GetXaxis()->GetNbins(); ++i) {
+  for (Int_t i = 0; i < ivnames->GetXaxis()->GetNbins(); ++i) {
     type_name_iv = ParseRegressionVariable(ivnames->GetXaxis()->GetBinLabel(i+1));
     fIndependentType.push_back(type_name_iv.first);
     fIndependentName.push_back(type_name_iv.second);
-    for (size_t j = 0; j < dvnames->GetXaxis()->GetNbins(); ++j) {
+    for (Int_t j = 0; j < dvnames->GetXaxis()->GetNbins(); ++j) {
       fSensitivity[j].push_back(-1.0*(*alphasM)(i,j));
     }
   }

--- a/Parity/src/QwCorrelator.cc
+++ b/Parity/src/QwCorrelator.cc
@@ -49,10 +49,10 @@ QwCorrelator::QwCorrelator(QwOptions &options, QwHelicityPattern& helicitypatter
     vector<TString> fIndependentName_t;
     vector<TString> fDependentName_t;
  
-    for (int i = 0; i < fIndependentName.size(); ++i) {
+    for (size_t i = 0; i < fIndependentName.size(); ++i) {
       fIndependentName_t.push_back(TString(fIndependentName.at(i)));
     }
-    for (int i = 0; i < fDependentName.size(); ++i) {
+    for (size_t i = 0; i < fDependentName.size(); ++i) {
       fDependentName_t.push_back(TString(fDependentName.at(i)));
     }
  
@@ -75,12 +75,12 @@ void QwCorrelator::FillCorrelator() {
 
   UInt_t error;
 
-  for (Int_t i = 0; i < fDependentVar.size(); ++i) {
+  for (size_t i = 0; i < fDependentVar.size(); ++i) {
     error |= fDependentVar.at(i)->GetErrorCode();
     fDependentValues.at(i) = (fDependentVar[i]->GetValue());
     //QwMessage << "Loading DV " << fDependentVar.at(i) << " into fDependentValues." << QwLog::endl;
   }
-  for (Int_t i = 0; i < fIndependentVar.size(); ++i) {
+  for (size_t i = 0; i < fIndependentVar.size(); ++i) {
     error |= fIndependentVar.at(i)->GetErrorCode();
     fIndependentValues.at(i) = (fIndependentVar[i]->GetValue());
     //QwMessage << "Loading IV " << fIndependentVar.at(i) << " into fIndependentValues." << QwLog::endl;

--- a/bin/pullgitinfo.py
+++ b/bin/pullgitinfo.py
@@ -10,7 +10,6 @@ os.chdir(sys.argv[1])
 f = os.popen("git remote -v && git log -n 1 && git status -bs && echo \"  ROOT version\" `root-config --version` && echo \" `cmake --version`\" && echo \"\nGenerated at `date`\"")
 
 boringstring = "";
-fullstring = "";
 
 if( f != 0):
     for line in f:
@@ -18,37 +17,19 @@ if( f != 0):
 else:
     boringstring = "git information unavailable"
 
-maxlen = 2048
-
 boringstring += "Source dir " + os.getcwd()
 boringstring += "\nBuild  dir " + presentcwd + "\n"
-
-if  len(boringstring) > maxlen:
-     print "WARNING:  Truncating info from git";
-     boringstring = boringstring[0:maxlen-1]
-
-for x in boringstring:
-    fullstring += '\\x'+x.encode('hex')
-
-
-     
 
 newheadertext = """#ifndef __GITINFO_HH
 #define __GITINFO_HH
 
 /*
     Generated automatically by cmake process
-    Encoding:
--------------------------------------------------------------
-""" + boringstring + """
--------------------------------------------------------------
 */
 
-#define __GITMAXINFO_SIZE 2048
-
-#define gGitInfoStr \"""" + fullstring + '\"' \
-+ \
-"""
+const char* const gGitInfo = R\"gitinfo(
+""" + boringstring + """
+)gitinfo\";
 
 #endif//__GITINFO_HH
 """


### PR DESCRIPTION
Minor change, but increases readability and maintainability.