### PR TITLE
Bugfix online epicscheck

### DIFF
--- a/Analysis/include/QwEventBuffer.h
+++ b/Analysis/include/QwEventBuffer.h
@@ -126,6 +126,8 @@ class QwEventBuffer: public MQwCodaControlEvent{
   Int_t  GetEvent();
   Int_t  WriteEvent(int* buffer);
 
+  Bool_t IsOnline(){return fOnline;};
+
   Bool_t IsROCConfigurationEvent(){
     return (fEvtType>=0x90 && fEvtType<=0xaf);
   };

--- a/Analysis/include/QwOptions.h
+++ b/Analysis/include/QwOptions.h
@@ -189,25 +189,15 @@ class QwOptions {
     void SetCommandLine(int argc, char* argv[], bool default_config_file = true);
 
     /// \brief Set a configuration file
-    void SetConfigFile(const std::string& configfile) {
-      fConfigFiles.clear();
-      fConfigFiles.push_back(configfile);
-      fParsed = false;
-    };
+    void SetConfigFile(const std::string& configfile);
 
     /// \brief Add a configuration file
-    void AddConfigFile(const std::string& configfile) {
-      QwMessage << "Adding user-defined configuration file "
-                << configfile << QwLog::endl;
-      fConfigFiles.push_back(configfile);
-      fParsed = false;
-    };
+    void AddConfigFile(const std::string& configfile);
 
     /// \brief Add some configuration files
     void AddConfigFile(std::vector<std::string> configfiles) {
       for (size_t i = 0; i < configfiles.size(); i++)
-        fConfigFiles.push_back(configfiles.at(i));
-      fParsed = false;
+	AddConfigFile(configfiles.at(i));
     };
 
     /// \brief List the configuration files

--- a/Analysis/src/QwOptions.cc
+++ b/Analysis/src/QwOptions.cc
@@ -143,6 +143,29 @@ void QwOptions::SetCommandLine(int argc, char* argv[], bool default_config_file)
   }
 }
 
+/**
+ * Set the named configuration file as the first (and initially only)
+ * one in the list.
+ * @param configfile Name of the config file, without path
+ */
+void QwOptions::SetConfigFile(const std::string& configfile)
+{
+  fConfigFiles.clear();
+  fConfigFiles.push_back(configfile);
+  fParsed = false;
+};
+
+/**
+ * Add the named configuration file to the list.
+ * @param configfile Name of the config file, without path
+ */
+void QwOptions::AddConfigFile(const std::string& configfile)
+{
+  QwMessage << "Adding user-defined configuration file "
+	    << configfile.c_str() << QwLog::endl;
+  fConfigFiles.push_back(configfile);
+  fParsed = false;
+};
 
 
 /**

--- a/Parity/main/QwParity.cc
+++ b/Parity/main/QwParity.cc
@@ -213,22 +213,24 @@ Int_t main(Int_t argc, Char_t* argv[])
     #endif // __USE_DATABASE__
 
     //  Find the first EPICS event and try to initialize
-    //  the blinder.
-    QwMessage << "Finding first EPICS event" << QwLog::endl;
-    while (eventbuffer.GetNextEvent() == CODA_OK) {
-      if (eventbuffer.IsEPICSEvent()) {
-	eventbuffer.FillEPICSData(epicsevent);
-	if (epicsevent.HasDataLoaded()) {
-	  helicitypattern.UpdateBlinder(epicsevent);
-	  // and break out of this event loop
-	  break;
+    //  the blinder, but only for disk files, not online.
+    if (! eventbuffer.IsOnline() ){
+      QwMessage << "Finding first EPICS event" << QwLog::endl;
+      while (eventbuffer.GetNextEvent() == CODA_OK) {
+	if (eventbuffer.IsEPICSEvent()) {
+	  eventbuffer.FillEPICSData(epicsevent);
+	  if (epicsevent.HasDataLoaded()) {
+	    helicitypattern.UpdateBlinder(epicsevent);
+	    // and break out of this event loop
+	    break;
+	  }
 	}
       }
+      epicsevent.ResetCounters();
+      //  Rewind stream
+      QwMessage << "Rewinding stream" << QwLog::endl;
+      eventbuffer.ReOpenStream();
     }
-    epicsevent.ResetCounters();
-    //  Rewind stream
-    QwMessage << "Rewinding stream" << QwLog::endl;
-    eventbuffer.ReOpenStream();
 
     ///  Start loop over events
     while (eventbuffer.GetNextEvent() == CODA_OK) {

--- a/Parity/prminput/online_apar.conf
+++ b/Parity/prminput/online_apar.conf
@@ -1,9 +1,8 @@
 online      = yes
 ET.hostname = adaq3.jlab.org
-ET.session  = par1
+ET.session  = par2
 ET.station  = realtime
 
-enable-mapfile   = yes
-circular-buffer = 10000
-
-enable-tree-trim = no
+##enable-mapfile   = yes
+##circular-buffer  = 10000
+##enable-tree-trim = no

--- a/Parity/prminput/online_apar.conf
+++ b/Parity/prminput/online_apar.conf
@@ -3,6 +3,10 @@ ET.hostname = adaq3.jlab.org
 ET.session  = par2
 ET.station  = realtime
 
+#  Set the interpreted run number to a very high value so we always 
+#  pick up the most recent paramter files.
+online.RunNumber = 999999
+
 ##enable-mapfile   = yes
 ##circular-buffer  = 10000
 ##enable-tree-trim = no


### PR DESCRIPTION
This should be the last thing needed to demonstrate we have completed issue #16.

To test the functionality of connecting to the 2ET system, you need to be on apar@adaq3, then:
1)  Start coda and start a run
2)  Execute `./build/qwparity --config prex.conf --add-config online_apar.conf `.  This should connect to the ET system and you should see helicity event processing messages for the first 30 patterns.  The event processing rate should match the CODA rate.
3)  In the ROOT file directory, a file `prexALL_0.root` should be created and its size should be growing.
4)  Use ctrl-C to stop the analysis process.  The rootfile should remain, and should contain the usual trees, if you inspect the contents.