### PR TITLE
Feature longer 64bit et buffer

### DIFF
--- a/evio/include/THaEtClient.h
+++ b/evio/include/THaEtClient.h
@@ -18,7 +18,8 @@
 
 #include "THaCodaData.h"
 
-#define ET_CHUNK_SIZE 5000
+#define ET_CHUNK_SIZE 2000
+// Default ET queue length set at 10,000 events at this time - 6-22-2019 Cameron Clarke
 //#define ET_CHUNK_SIZE 150
 #include "et.h"
 #include <iostream>

--- a/evio/include/THaEtClient.h
+++ b/evio/include/THaEtClient.h
@@ -18,7 +18,8 @@
 
 #include "THaCodaData.h"
 
-#define ET_CHUNK_SIZE 150
+#define ET_CHUNK_SIZE 5000
+//#define ET_CHUNK_SIZE 150
 #include "et.h"
 #include <iostream>
 #include <stdlib.h>


### PR DESCRIPTION
I've increased the cue length for the 64 bit ET station that Japan
   attaches to. This is needed to allow for at least graceful failure of
   the analyzer when the analysis rate gets behind the data rate

   This number (5000 * 2 = 10000) needs to be less than the total
   queue length of the 64 bit ET system (currently set at 100000 in the
   start2ndET script that is executed in the startcoda script). If the
   japan cue gets to be near the 64 bit ET system queue length then
   it turns the station into ~blocking mode (and it is coded to be non-
   blocking currently).

   This change from 150 * 2=300 to 5000 * 2=10000 cue length is a choice,
   and if we would prefer to see relatively live data instead of continuous
   data during analysis-slower-than-CODA running then we should reset this
   number back down to a lower number. The reason I would like this to
   be relatively continuous for now is because we do not have the
   injector SIS3801 scaler reading event number and pattern phase correctly
   and so re-catching the Helicity phase is non-trivial (this will not
   be a problem during PREX running once these scalers are set up correctly)