### PR TITLE
Turn off circular buffer to allow for faster

### DIFF
--- a/Parity/prminput/simulate_online_disk_file.conf
+++ b/Parity/prminput/simulate_online_disk_file.conf
@@ -10,7 +10,8 @@
 #  Update every N events (for TMapFiles and TFile)
 mapfile-update-interval = 1000
 # circular-buffer  = 864000 ## 240 Hz Mode: 864000 = 240 * 60 * 60 
-circular-buffer  = 108000 ## 30 Hz Mode: 108000 = 30 *60 *60
+# circular-buffer  = 108000 ## 30 Hz Mode: 108000 = 30 *60 *60
+# circular-buffer = 0 # Default is 0, set it to 0 to save significant computation time not using the circular buffer
 # compression-level arg (=1) TFile compression level
 compression-level = 0
 


### PR DESCRIPTION
Turn off circular buffer to allow for faster online analyzer running