### PR TITLE
Modified the stability cut functionality.

### DIFF
--- a/Parity/prminput/prexCH_beamline_eventcuts.1329-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.1329-.map
@@ -27,7 +27,7 @@ EVENTCUTS = 3
 !***************************************************
 !for bcm devices
 !device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability percentage
- bcm, bcm_an_ds3,		2.0,	1e6,	g,	0.2
+ bcm, bcm_an_ds3,		2.0,	1e6,	g,	0.75
 
 !for parity mock data run 1000 9.98608e+06
 !bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 

--- a/Parity/prminput/prexCH_beamline_eventcuts.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.map
@@ -27,7 +27,7 @@ EVENTCUTS = 3
 !***************************************************
 !for bcm devices
 !device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability percentage
- bcm, bcm_an_ds3,		1.0,	1e6,	g,	0.2
+ bcm, bcm_an_ds3,		1.0,	1e6,	g,	0.75
 
 !for parity mock data run 1000 9.98608e+06
 !bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 

--- a/Parity/src/QwEventRing.cc
+++ b/Parity/src/QwEventRing.cc
@@ -1,4 +1,3 @@
-
 #include "QwEventRing.h"
 
 
@@ -73,27 +72,28 @@ void QwEventRing::push(QwSubsystemArrayParity &event)
   
 
   if (bEVENT_READY){
-    fEvent_Ring[fNextToBeFilled]=event;//copy the current good event to the ring 
+    Int_t thisevent = fNextToBeFilled;
+    fEvent_Ring[thisevent]=event;//copy the current good event to the ring 
     if (bStability){
       fRollingAvg.AccumulateAllRunningSum(event);
     }
 
 
-    if (bDEBUG) QwMessage<<" Filled at "<<fNextToBeFilled;//<<"Ring count "<<fRing_Count<<QwLog::endl; 
-    if (bDEBUG_Write) fprintf(out_file," Filled at %d ",fNextToBeFilled);
+    if (bDEBUG) QwMessage<<" Filled at "<<thisevent;//<<"Ring count "<<fRing_Count<<QwLog::endl; 
+    if (bDEBUG_Write) fprintf(out_file," Filled at %d ",thisevent);
 
 
-    fNextToBeFilled=(fNextToBeFilled+1)%fRING_SIZE;
+    fNextToBeFilled=(thisevent+1)%fRING_SIZE;
     
     if(fNextToBeFilled == 0){
       //then we have RING_SIZE events to process
-      if (bDEBUG) QwMessage<<" RING FILLED "<<fNextToBeFilled+1; //<<QwLog::endl; 
+      if (bDEBUG) QwMessage<<" RING FILLED "<<thisevent; //<<QwLog::endl; 
       if (bDEBUG_Write) fprintf(out_file," RING FILLED ");
       bRING_READY=kTRUE;//ring is filled with good multiplets
-      fNextToBeFilled=0;//next event to be filled
-      fNextToBeRead=0;//first element in the ring  
+      fNextToBeFilled=0;//next event to be filled is the first element  
+    }
       //check for current ramps
-      if (bStability){
+    if (bRING_READY && bStability){
 	fRollingAvg.CalculateRunningAverage();
 	/*
 	//The fRollingAvg dose not contain any regular errorcodes since it only accumulate rolling sum for errorflag==0 event.
@@ -103,12 +103,18 @@ void QwEventRing::push(QwSubsystemArrayParity &event)
 	//stability cut faliures
 	*/
 	fRollingAvg.UpdateErrorFlag(); //to update the global error code in the fRollingAvg
-	for(Int_t i=0;i<fRING_SIZE;i++){
-	  fEvent_Ring[i].UpdateErrorFlag(fRollingAvg);
-	  fEvent_Ring[i].UpdateErrorFlag();
+	if ( (fRollingAvg.GetEventcutErrorFlag()  && kBeamStabilityError)!=0 )
+	  {
+	  //  This test really needs to determine in any of the subelements
+	  //  might have a local stability cut failure, instead of just this
+	  //  global stability cut failure.
+	  for(Int_t i=0;i<fRING_SIZE;i++){
+	    fEvent_Ring[i].UpdateErrorFlag(fRollingAvg);
+	    fEvent_Ring[i].UpdateErrorFlag();
+	  }
 	}
 	
-      }
+	//      }
     }
     //ring processing is done at a separate location
   }else{


### PR DESCRIPTION
Previously (see discussion in issue #92) the stability cut was only
evaluated when we reached the end of the event ring.  Now the stability
cut will be evaluated as each event is pushed into the ring.
This improves the detection of beam trips.

However, there's still an issue with recognizing the start of the
beam trip and really cutting a full "ring.size" events before the trip.
This version does definitely cut away before the beam trips, but it
is fewer events than it ought to be.

The next stage should refactor how we do the stability check so that
we look at the width and at the values of the event which is being
pushed into the ring.  A failed single-event cut on a channel we are
monitoring stability should also trigger the stability cut.
Possibly a single-event change which is "large" should also trigger
the stability cut.

Due to the functionality change in the event cut, I also changed the
stability cut settings in the CHA beamline files.