### PR TITLE
Feature pairanalysis

### DIFF
--- a/Parity/include/QwBlinder.h
+++ b/Parity/include/QwBlinder.h
@@ -179,6 +179,13 @@ class QwBlinder {
       if (CheckBlindability()!=kNotBlindable)
 	diff.Blind(this);
     };
+    /// Blind the pair asymmetry 
+    /// and only check fBlindingStrategy to avoid  overcounting fPatternCounters
+    void  BlindPair(QwSubsystemArrayParity& diff) {
+      if (fBlindingStrategy!=kDisabled)
+	diff.Blind(this);
+    };
+
     /// Unblind the asymmetry of an array of subsystems
     void  UnBlind(QwSubsystemArrayParity& diff) {
       diff.UnBlind(this);
@@ -189,6 +196,12 @@ class QwBlinder {
       if (CheckBlindability()!=kNotBlindable)
 	diff.Blind(this, yield);
     };
+    /// Blind the pair difference of an array of subsystems
+    void  BlindPair(QwSubsystemArrayParity& diff, const QwSubsystemArrayParity& yield) {
+      if (fBlindingStrategy!=kDisabled)
+	diff.Blind(this, yield);
+    };
+
     /// Unblind the difference of an array of subsystems
     void  UnBlind(QwSubsystemArrayParity& diff, const QwSubsystemArrayParity& yield) {
       diff.UnBlind(this, yield);

--- a/Parity/include/QwBlinder.h
+++ b/Parity/include/QwBlinder.h
@@ -176,13 +176,13 @@ class QwBlinder {
 
     /// Blind the asymmetry of an array of subsystems
     void  Blind(QwSubsystemArrayParity& diff) {
-      if (CheckBlindability()!=kNotBlindable)
+      if (CheckBlindability(fPatternCounters)!=kNotBlindable)
 	diff.Blind(this);
     };
     /// Blind the pair asymmetry 
     /// and only check fBlindingStrategy to avoid  overcounting fPatternCounters
     void  BlindPair(QwSubsystemArrayParity& diff) {
-      if (fBlindingStrategy!=kDisabled)
+      if (CheckBlindability(fPairCounters)!=kNotBlindable)
 	diff.Blind(this);
     };
 
@@ -193,12 +193,12 @@ class QwBlinder {
 
     /// Blind the difference of an array of subsystems
     void  Blind(QwSubsystemArrayParity& diff, const QwSubsystemArrayParity& yield) {
-      if (CheckBlindability()!=kNotBlindable)
+      if (CheckBlindability(fPatternCounters)!=kNotBlindable)
 	diff.Blind(this, yield);
     };
     /// Blind the pair difference of an array of subsystems
     void  BlindPair(QwSubsystemArrayParity& diff, const QwSubsystemArrayParity& yield) {
-      if (fBlindingStrategy!=kDisabled)
+      if (CheckBlindability(fPairCounters)!=kNotBlindable)
 	diff.Blind(this, yield);
     };
 
@@ -226,7 +226,7 @@ class QwBlinder {
     Double_t fBeamCurrentThreshold;
     Bool_t fBeamIsPresent;
 
-    EQwBlinderStatus CheckBlindability();
+    EQwBlinderStatus CheckBlindability(std::vector<Int_t> &fCounters);
     Bool_t fBlinderIsOkay;
 
     
@@ -288,6 +288,7 @@ class QwBlinder {
     std::vector<UChar_t> GenerateDigest(const TString& input) const;
 
     std::vector<Int_t> fPatternCounters; ///< Counts the number of events in each failure mode
+    std::vector<Int_t> fPairCounters; ///< Counts the number of helicity pairs in each failure mode
 };
 
 #endif //__QWBLINDER__

--- a/Parity/include/QwBlinder.h
+++ b/Parity/include/QwBlinder.h
@@ -110,7 +110,9 @@ class QwBlinder {
 
 
     void  WriteFinalValuesToDB(QwParityDB* db);
-    void  PrintFinalValues();
+    void  PrintCountersValues(std::vector<Int_t> fCounters, TString counter_type);
+    void  PrintFinalValues(Int_t kVerbosity=1);
+
 
 #ifdef __USE_DATABASE__
     /// Write to the database

--- a/Parity/include/QwHelicityPattern.h
+++ b/Parity/include/QwHelicityPattern.h
@@ -41,6 +41,8 @@ class QwHelicityPattern {
  public:
   /// Constructor with subsystem array
   QwHelicityPattern(QwSubsystemArrayParity &event, const TString &run = "0");
+  /// \brief Copy constructor by reference
+  QwHelicityPattern(const QwHelicityPattern& source);
   /// Virtual destructor
   virtual ~QwHelicityPattern() { };
 
@@ -113,7 +115,8 @@ class QwHelicityPattern {
 
   void  AccumulateBurstSum();
   void  AccumulateRunningBurstSum();
-  void  AccumulateRunningSum();
+  void  AccumulateRunningSum(){AccumulateRunningSum(*this);};
+  void  AccumulateRunningSum(QwHelicityPattern &entry);
 
   void  CalculateBurstAverage();
   void  CalculateRunningBurstAverage();
@@ -139,7 +142,7 @@ class QwHelicityPattern {
 
   void  WritePromptSummary(QwPromptSummary *ps);
 
-  Bool_t IsGoodAsymmetry(){ return fPatternIsGood;};
+  Bool_t IsGoodAsymmetry();
   UInt_t GetEventcutErrorFlag() const{
     return fAsymmetry.GetEventcutErrorFlag();
   };
@@ -212,11 +215,6 @@ class QwHelicityPattern {
   // Running sum/average of the yield and asymmetry
   Bool_t fEnableRunningSum;
   Bool_t fPrintRunningSum;
-  QwSubsystemArrayParity fRunningYield;
-  QwSubsystemArrayParity fRunningDifference;
-  QwSubsystemArrayParity fRunningAsymmetry;
-  QwSubsystemArrayParity fRunningAsymmetry1;
-  QwSubsystemArrayParity fRunningAsymmetry2;
 
   Bool_t fEnableDifference;
   QwSubsystemArrayParity fDifference;

--- a/Parity/include/QwHelicityPattern.h
+++ b/Parity/include/QwHelicityPattern.h
@@ -54,6 +54,11 @@ class QwHelicityPattern {
   void  LoadEventData(QwSubsystemArrayParity &event);
   Bool_t HasDataLoaded() const { return fIsDataLoaded; };
 
+  Bool_t PairAsymmetryIsGood();
+  Bool_t NextPairIsComplete();
+  void   CalculatePairAsymmetry();
+  void   ClearPairData(){fPairYield.ClearEventData();fPairDifference.ClearEventData(); fPairAsymmetry.ClearEventData();}
+
   Bool_t IsCompletePattern() const;
 
   Bool_t IsEndOfBurst(){
@@ -112,6 +117,11 @@ class QwHelicityPattern {
   QwSubsystemArrayParity& GetBurstYield()      { return fBurstYield; };
   QwSubsystemArrayParity& GetBurstDifference() { return fBurstDifference; };
   QwSubsystemArrayParity& GetBurstAsymmetry()  { return fBurstAsymmetry; };
+
+  // wish these could be const references, but ConstructBranchAndVector messes with object
+  QwSubsystemArrayParity& GetPairYield()      { return fPairYield; };
+  QwSubsystemArrayParity& GetPairDifference() { return fPairDifference; };
+  QwSubsystemArrayParity& GetPairAsymmetry()  { return fPairAsymmetry; };
 
   void  AccumulateBurstSum();
   void  AccumulateRunningBurstSum();
@@ -201,6 +211,10 @@ class QwHelicityPattern {
   QwSubsystemArrayParity fAsymmetry1;
   QwSubsystemArrayParity fAsymmetry2;
 
+  QwSubsystemArrayParity fPairYield;
+  QwSubsystemArrayParity fPairDifference;
+  QwSubsystemArrayParity fPairAsymmetry;
+
   // Burst sum/difference of the yield and asymmetry
   Int_t fBurstLength;
   Bool_t fEnableBurstSum;
@@ -225,6 +239,9 @@ class QwHelicityPattern {
   Long_t fLastWindowNumber;
   Long_t fLastPatternNumber;
   Int_t  fLastPhaseNumber;
+
+  size_t  fNextPair;
+  Bool_t fPairIsGood;
 
   Bool_t fPatternIsGood;
 

--- a/Parity/include/QwHelicityPattern.h
+++ b/Parity/include/QwHelicityPattern.h
@@ -127,6 +127,7 @@ class QwHelicityPattern {
   void  AccumulateRunningBurstSum();
   void  AccumulateRunningSum(){AccumulateRunningSum(*this);};
   void  AccumulateRunningSum(QwHelicityPattern &entry);
+  void  AccumulatePairRunningSum(QwHelicityPattern &entry);
 
   void  CalculateBurstAverage();
   void  CalculateRunningBurstAverage();
@@ -205,6 +206,7 @@ class QwHelicityPattern {
 
   // Yield and asymmetry of a single helicity pattern
   QwSubsystemArrayParity fYield;
+  QwSubsystemArrayParity fDifference;
   QwSubsystemArrayParity fAsymmetry;
   // Alternate asymmetry calculations
   Bool_t fEnableAlternateAsym;
@@ -231,7 +233,6 @@ class QwHelicityPattern {
   Bool_t fPrintRunningSum;
 
   Bool_t fEnableDifference;
-  QwSubsystemArrayParity fDifference;
   QwSubsystemArrayParity fAlternateDiff;
   QwSubsystemArrayParity fPositiveHelicitySum;
   QwSubsystemArrayParity fNegativeHelicitySum;

--- a/Parity/main/QwParity.cc
+++ b/Parity/main/QwParity.cc
@@ -296,6 +296,7 @@ Int_t main(Int_t argc, Char_t* argv[])
           helicitypattern.LoadEventData(ringoutput);
 
 	  if (helicitypattern.PairAsymmetryIsGood()) {
+	    patternsum.AccumulatePairRunningSum(helicitypattern);
 	    // Fill pair tree branches
 	    treerootfile->FillTreeBranches(helicitypattern.GetPairYield());
 	    treerootfile->FillTreeBranches(helicitypattern.GetPairAsymmetry());

--- a/Parity/main/QwParity.cc
+++ b/Parity/main/QwParity.cc
@@ -188,6 +188,9 @@ Int_t main(Int_t argc, Char_t* argv[])
     //  Construct tree branches
     treerootfile->ConstructTreeBranches("evt", "MPS event data tree", ringoutput);
     treerootfile->ConstructTreeBranches("mul", "Helicity event data tree", helicitypattern);
+    burstrootfile->ConstructTreeBranches("pair", "Pair tree", helicitypattern.GetPairYield(),"yield_");
+    burstrootfile->ConstructTreeBranches("pair", "Pair tree", helicitypattern.GetPairAsymmetry(),"asym_");
+    burstrootfile->ConstructTreeBranches("pair", "Pair tree", helicitypattern.GetPairDifference(),"diff_");
     treerootfile->ConstructTreeBranches("mulc", "Helicity event data tree (corrected)", helicitypattern.return_regression());
     treerootfile->ConstructTreeBranches("mulc_lrb", "Helicity event data tree (corrected by LinRegBlue)", helicitypattern.return_regress_from_LRB());
     treerootfile->ConstructTreeBranches("slow", "EPICS and slow control tree", epicsevent);
@@ -293,6 +296,16 @@ Int_t main(Int_t argc, Char_t* argv[])
           // Load the event into the helicity pattern
           helicitypattern.LoadEventData(ringoutput);
 
+	  if (helicitypattern.PairAsymmetryIsGood()) {
+	    // Fill pair tree branches
+	    treerootfile->FillTreeBranches(helicitypattern.GetPairYield());
+	    treerootfile->FillTreeBranches(helicitypattern.GetPairAsymmetry());
+	    treerootfile->FillTreeBranches(helicitypattern.GetPairDifference());
+	    treerootfile->FillTree("pair");
+	    
+	    // Clear the data
+	    helicitypattern.ClearPairData();
+	  }
           // Check to see if we can calculate helicity pattern asymmetry, do so, and report if it worked
           if (helicitypattern.IsGoodAsymmetry()) {
 	    patternsum.AccumulateRunningSum(helicitypattern);

--- a/Parity/main/QwParity.cc
+++ b/Parity/main/QwParity.cc
@@ -188,9 +188,9 @@ Int_t main(Int_t argc, Char_t* argv[])
     //  Construct tree branches
     treerootfile->ConstructTreeBranches("evt", "MPS event data tree", ringoutput);
     treerootfile->ConstructTreeBranches("mul", "Helicity event data tree", helicitypattern);
-    burstrootfile->ConstructTreeBranches("pair", "Pair tree", helicitypattern.GetPairYield(),"yield_");
-    burstrootfile->ConstructTreeBranches("pair", "Pair tree", helicitypattern.GetPairAsymmetry(),"asym_");
-    burstrootfile->ConstructTreeBranches("pair", "Pair tree", helicitypattern.GetPairDifference(),"diff_");
+    burstrootfile->ConstructTreeBranches("pr", "Pair tree", helicitypattern.GetPairYield(),"yield_");
+    burstrootfile->ConstructTreeBranches("pr", "Pair tree", helicitypattern.GetPairAsymmetry(),"asym_");
+    burstrootfile->ConstructTreeBranches("pr", "Pair tree", helicitypattern.GetPairDifference(),"diff_");
     treerootfile->ConstructTreeBranches("mulc", "Helicity event data tree (corrected)", helicitypattern.return_regression());
     treerootfile->ConstructTreeBranches("mulc_lrb", "Helicity event data tree (corrected by LinRegBlue)", helicitypattern.return_regress_from_LRB());
     treerootfile->ConstructTreeBranches("slow", "EPICS and slow control tree", epicsevent);
@@ -301,7 +301,7 @@ Int_t main(Int_t argc, Char_t* argv[])
 	    treerootfile->FillTreeBranches(helicitypattern.GetPairYield());
 	    treerootfile->FillTreeBranches(helicitypattern.GetPairAsymmetry());
 	    treerootfile->FillTreeBranches(helicitypattern.GetPairDifference());
-	    treerootfile->FillTree("pair");
+	    treerootfile->FillTree("pr");
 	    
 	    // Clear the data
 	    helicitypattern.ClearPairData();

--- a/Parity/main/QwParity.cc
+++ b/Parity/main/QwParity.cc
@@ -190,7 +190,6 @@ Int_t main(Int_t argc, Char_t* argv[])
     treerootfile->ConstructTreeBranches("mul", "Helicity event data tree", helicitypattern);
     burstrootfile->ConstructTreeBranches("pr", "Pair tree", helicitypattern.GetPairYield(),"yield_");
     burstrootfile->ConstructTreeBranches("pr", "Pair tree", helicitypattern.GetPairAsymmetry(),"asym_");
-    burstrootfile->ConstructTreeBranches("pr", "Pair tree", helicitypattern.GetPairDifference(),"diff_");
     treerootfile->ConstructTreeBranches("mulc", "Helicity event data tree (corrected)", helicitypattern.return_regression());
     treerootfile->ConstructTreeBranches("mulc_lrb", "Helicity event data tree (corrected by LinRegBlue)", helicitypattern.return_regress_from_LRB());
     treerootfile->ConstructTreeBranches("slow", "EPICS and slow control tree", epicsevent);

--- a/Parity/src/QwBlinder.cc
+++ b/Parity/src/QwBlinder.cc
@@ -884,24 +884,15 @@ std::vector<UChar_t> QwBlinder::GenerateDigest(const TString& input) const
 /**
  * Print a summary of the blinding/unblinding test
  */
-void QwBlinder::PrintFinalValues()
+void QwBlinder::PrintFinalValues(Int_t kVerbosity)
 {
   QwMessage << "QwBlinder::PrintFinalValues():  Begin summary"    << QwLog::endl;
   QwMessage << "================================================" << QwLog::endl;
-  QwMessage << "Blinder Passed Patterns"  << QwLog::endl;
-  QwMessage << "\tPatterns with blinding disabled: " << fPatternCounters.at(kBlinderCount_Disabled) << QwLog::endl;
-  QwMessage << "\tPatterns on a non-blindable target: " << fPatternCounters.at(kBlinderCount_NonBlindable) << QwLog::endl;
-  QwMessage << "\tPatterns with transverse beam: " << fPatternCounters.at(kBlinderCount_Transverse) << QwLog::endl;
-  QwMessage << "\tPatterns on blindable target with beam present: " << fPatternCounters.at(kBlinderCount_Blindable) << QwLog::endl;
-  QwMessage << "Blinder Failed Patterns"  << QwLog::endl;
-  QwMessage << "\tPatterns with unknown target position: " << fPatternCounters.at(kBlinderCount_UnknownTarget) << QwLog::endl;
-  QwMessage << "\tPatterns with changed target position: " << fPatternCounters.at(kBlinderCount_ChangedTarget) << QwLog::endl;
-  QwMessage << "\tPatterns with an undefined Wien setting: " << fPatternCounters.at(kBlinderCount_UndefinedWien) << QwLog::endl;
-  QwMessage << "\tPatterns with a changed Wien setting: " << fPatternCounters.at(kBlinderCount_ChangedWien) << QwLog::endl;
-  QwMessage << "\tPatterns with an undefined IHWP setting: " << fPatternCounters.at(kBlinderCount_UndefinedIHWP) << QwLog::endl;
-  QwMessage << "\tPatterns with a changed IHWP setting: " << fPatternCounters.at(kBlinderCount_ChangedIHWP) << QwLog::endl;
-  QwMessage << "\tPatterns on blindable target with no beam: " << fPatternCounters.at(kBlinderCount_NoBeam) << QwLog::endl;
-  QwMessage << "\tPatterns with other blinding failure: " << fPatternCounters.at(kBlinderCount_OtherFailure) << QwLog::endl;
+  PrintCountersValues(fPatternCounters, "Patterns");
+  if(kVerbosity==1){
+    QwMessage << "================================================" << QwLog::endl;
+    PrintCountersValues(fPairCounters, "Pairs");
+  }
   QwMessage << "================================================" << QwLog::endl;
   QwMessage << "The blinding parameters checksum for seed ID "
             << fSeedID << " is:" << QwLog::endl;
@@ -930,6 +921,37 @@ void QwBlinder::PrintFinalValues()
   }
   QwMessage << "================================================" << QwLog::endl;
   QwMessage << "QwBlinder::PrintFinalValues():  End of summary"   << QwLog::endl;
+}
+
+void QwBlinder::PrintCountersValues(std::vector<Int_t> fCounters, TString counter_type)
+{
+  QwMessage << "Blinder Passed " << counter_type  << QwLog::endl;
+  QwMessage << "\t" << counter_type 
+	    << " with blinding disabled: " << fCounters.at(kBlinderCount_Disabled) << QwLog::endl;
+  QwMessage << "\t" << counter_type 
+	    << " on a non-blindable target: " << fCounters.at(kBlinderCount_NonBlindable) << QwLog::endl;
+  QwMessage << "\t" << counter_type
+	    << " with transverse beam: " << fCounters.at(kBlinderCount_Transverse) << QwLog::endl;
+  QwMessage << "\t" << counter_type
+	    << " on blindable target with beam present: " << fCounters.at(kBlinderCount_Blindable) << QwLog::endl;
+  QwMessage << "Blinder Failed " << counter_type  << QwLog::endl;
+  QwMessage << "\t" << counter_type
+	    << " with unknown target position: " << fCounters.at(kBlinderCount_UnknownTarget) << QwLog::endl;
+  QwMessage << "\t" << counter_type 
+	    << " with changed target position: " << fCounters.at(kBlinderCount_ChangedTarget) << QwLog::endl;
+  QwMessage << "\t" << counter_type 
+	    << " with an undefined Wien setting: " << fCounters.at(kBlinderCount_UndefinedWien) << QwLog::endl;
+  QwMessage << "\t" << counter_type
+	    << " with a changed Wien setting: " << fCounters.at(kBlinderCount_ChangedWien) << QwLog::endl;
+  QwMessage << "\t" << counter_type
+	    << " with an undefined IHWP setting: " << fCounters.at(kBlinderCount_UndefinedIHWP) << QwLog::endl;
+  QwMessage << "\t" << counter_type
+	    << " with a changed IHWP setting: " << fCounters.at(kBlinderCount_ChangedIHWP) << QwLog::endl;
+  QwMessage << "\t" << counter_type
+	    << " on blindable target with no beam: " << fCounters.at(kBlinderCount_NoBeam) << QwLog::endl;
+  QwMessage << "\t" << counter_type
+	    << " with other blinding failure: " << fCounters.at(kBlinderCount_OtherFailure) << QwLog::endl;
+
 }
 
 

--- a/Parity/src/QwBlinder.cc
+++ b/Parity/src/QwBlinder.cc
@@ -93,6 +93,7 @@ QwBlinder::QwBlinder(const EQwBlindingStrategy blinding_strategy):
   // Calculate set of test values
   InitTestValues(10);
   fPatternCounters.resize(kBlinderCount_NumCounters);
+  fPairCounters.resize(kBlinderCount_NumCounters);
 }
 
 
@@ -1083,67 +1084,67 @@ void QwBlinder::SetIHWPPolarity(Int_t ihwppolarity)
 }
 
 
-QwBlinder::EQwBlinderStatus QwBlinder::CheckBlindability()
+QwBlinder::EQwBlinderStatus QwBlinder::CheckBlindability(std::vector<Int_t> &fCounters)
 {
   EQwBlinderStatus status = QwBlinder::kBlindableFail;
   if (fBlindingStrategy == kDisabled) {
     status = QwBlinder::kNotBlindable;
-    fPatternCounters.at(kBlinderCount_Disabled)++;
+    fCounters.at(kBlinderCount_Disabled)++;
   } else if (fTargetBlindability == QwBlinder::kIndeterminate) {
     QwDebug  << "QwBlinder::CheckBlindability:  The target blindability is not determined.  "
 	     << "Fail this pattern." << QwLog::endl;
     status = QwBlinder::kBlindableFail;
-    fPatternCounters.at(kBlinderCount_UnknownTarget)++;    
+    fCounters.at(kBlinderCount_UnknownTarget)++;    
   } else if (fTargetBlindability!=fTargetBlindability_firstread
 	     && !fTargetPositionForced) {
     QwDebug << "QwBlinder::CheckBlindability:  The target blindability has changed.  "
 	    << "Fail this pattern." << QwLog::endl;
     status = QwBlinder::kBlindableFail;
-    fPatternCounters.at(kBlinderCount_ChangedTarget)++;
+    fCounters.at(kBlinderCount_ChangedTarget)++;
   } else if (fTargetBlindability==kNotBlindable) {
     //  This isn't a blindable target, so don't do anything.
     status = QwBlinder::kNotBlindable;
-    fPatternCounters.at(kBlinderCount_NonBlindable)++;
+    fCounters.at(kBlinderCount_NonBlindable)++;
   } else if (fTargetBlindability==kBlindable &&
 	     fWienMode != fWienMode_firstread) {
     //  Wien status changed.  Fail
     status = QwBlinder::kBlindableFail;
-    fPatternCounters.at(kBlinderCount_ChangedWien)++;
+    fCounters.at(kBlinderCount_ChangedWien)++;
   } else if (fTargetBlindability==kBlindable &&
 	     fIHWPPolarity != fIHWPPolarity_firstread) {
     //  IHWP status changed.  Fail
     status = QwBlinder::kBlindableFail;
-    fPatternCounters.at(kBlinderCount_ChangedIHWP)++;
+    fCounters.at(kBlinderCount_ChangedIHWP)++;
   } else if (fTargetBlindability==kBlindable &&
 	     fWienMode == kWienIndeterminate) {
     //  Wien status isn't determined.  Fail.
     status = QwBlinder::kBlindableFail;
-    fPatternCounters.at(kBlinderCount_UndefinedWien)++;
+    fCounters.at(kBlinderCount_UndefinedWien)++;
   } else if (fTargetBlindability==kBlindable &&
 	     fIHWPPolarity==0) {
     //  IHWP status isn't determined.  Fail.
     status = QwBlinder::kBlindableFail;
-    fPatternCounters.at(kBlinderCount_UndefinedIHWP)++;
+    fCounters.at(kBlinderCount_UndefinedIHWP)++;
   } else if (fTargetBlindability==kBlindable &&
 	    (fWienMode == kWienVertTrans || fWienMode == kWienHorizTrans)) {
     //  We don't have longitudinal beam, so don't blind.
     status = QwBlinder::kNotBlindable;
-    fPatternCounters.at(kBlinderCount_Transverse)++;
+    fCounters.at(kBlinderCount_Transverse)++;
   } else if (fTargetBlindability==kBlindable 
 	     && fBeamIsPresent) {
     //  This is a blindable target and the beam is sufficent.
     status = QwBlinder::kBlindable;
-    fPatternCounters.at(kBlinderCount_Blindable)++;
+    fCounters.at(kBlinderCount_Blindable)++;
   } else if (fTargetBlindability==kBlindable 
 	     && (! fBeamIsPresent) ) {
     //  This is a blindable target but there is insufficent beam present
     status = QwBlinder::kBlindableFail;
-    fPatternCounters.at(kBlinderCount_NoBeam)++;
+    fCounters.at(kBlinderCount_NoBeam)++;
   } else {
     QwError << "QwBlinder::CheckBlindability:  The pattern blindability is unclear.  "
 	     << "Fail this pattern." << QwLog::endl;
     status = QwBlinder::kBlindableFail;
-    fPatternCounters.at(kBlinderCount_OtherFailure)++;
+    fCounters.at(kBlinderCount_OtherFailure)++;
   }
   //
   fBlinderIsOkay = (status != QwBlinder::kBlindableFail);

--- a/Parity/src/QwBlinder.cc
+++ b/Parity/src/QwBlinder.cc
@@ -886,6 +886,12 @@ std::vector<UChar_t> QwBlinder::GenerateDigest(const TString& input) const
  */
 void QwBlinder::PrintFinalValues(Int_t kVerbosity)
 {
+  Int_t total_count = 0;
+  for (size_t i=0; i<kBlinderCount_NumCounters; i++){
+    total_count += fPatternCounters.at(i);
+  }
+  if (total_count<=0) return;
+  
   QwMessage << "QwBlinder::PrintFinalValues():  Begin summary"    << QwLog::endl;
   QwMessage << "================================================" << QwLog::endl;
   PrintCountersValues(fPatternCounters, "Patterns");

--- a/Parity/src/QwHelicity.cc
+++ b/Parity/src/QwHelicity.cc
@@ -1278,6 +1278,10 @@ void  QwHelicity::ConstructBranchAndVector(TTree *tree, TString &prefix, std::ve
     }
   else if(fHistoType==kHelSavePattern)
     {
+      basename = "actual_helicity";    //predicted actual helicity before being delayed.
+      values.push_back(0.0);
+      tree->Branch(basename, &(values.back()), basename+"/D");
+      //
       basename = "actual_pattern_polarity";
       values.push_back(0.0);
       tree->Branch(basename, &(values.back()), basename+"/D");
@@ -1343,6 +1347,9 @@ void  QwHelicity::ConstructBranch(TTree *tree, TString &prefix)
     }
   else if(fHistoType==kHelSavePattern)
     {
+      basename = "actual_helicity";    //predicted actual helicity before being delayed.
+      tree->Branch(basename, &fHelicityActual, basename+"/I");
+      //
       basename = "actual_pattern_polarity";
       tree->Branch(basename, &fActualPatternPolarity, basename+"/I");
       //
@@ -1402,6 +1409,9 @@ void  QwHelicity::ConstructBranch(TTree *tree, TString &prefix, QwParameterFile&
     }
   else if(fHistoType==kHelSavePattern)
     {
+      basename = "actual_helicity";    //predicted actual helicity before being delayed.
+      tree->Branch(basename, &fHelicityActual, basename+"/I");
+      //
       basename = "actual_pattern_polarity";
       tree->Branch(basename, &fActualPatternPolarity, basename+"/I");
       //
@@ -1447,6 +1457,7 @@ void  QwHelicity::FillTreeVector(std::vector<Double_t> &values) const
     }
   else if(fHistoType==kHelSavePattern)
     {
+      values[index++] = fHelicityActual;
       values[index++] = fActualPatternPolarity;
       values[index++] = fPreviousPatternPolarity;
       values[index++] = fDelayedPatternPolarity;

--- a/Parity/src/QwHelicityPattern.cc
+++ b/Parity/src/QwHelicityPattern.cc
@@ -374,7 +374,7 @@ void  QwHelicityPattern::CalculatePairAsymmetry()
 		<< "; Asymmetry computation aborted!"<<QwLog::endl;
 	fPairIsGood = kFALSE;
 	// there is a different number of plus and minus helicity window.
-	QwError<<" QwHelicityPattern::CalculateAsymmetry == \n"
+	QwError<<" QwHelicityPattern::CalculatePairAsymmetry == \n"
 	       <<" you do not have the same number of positive and negative \n"
 	       <<" impossible to compute assymetry \n"
 	       <<" dropping every thing -- pattern number ="<<fCurrentPatternNumber<<QwLog::endl;

--- a/Parity/src/QwHelicityPattern.cc
+++ b/Parity/src/QwHelicityPattern.cc
@@ -388,7 +388,7 @@ void  QwHelicityPattern::CalculatePairAsymmetry()
       //      // Update the blinder if conditions have changed
       //      UpdateBlinder(fPairYield);
       //  Only blind the difference if we're using the real helicity.
-      fBlinder.Blind(fPairDifference,fPairYield);
+      fBlinder.BlindPair(fPairDifference,fPairYield);
       //  Update the global error code in fDifference, and use it
       //  to update the errors in fYield, in case blinder errors
       //  can propagate to the global error.

--- a/Parity/src/QwHelicityPattern.cc
+++ b/Parity/src/QwHelicityPattern.cc
@@ -367,11 +367,20 @@ void  QwHelicityPattern::CalculatePairAsymmetry()
       } else if (fHelicity[firstevt] == minushel && fHelicity[firstevt]!=fHelicity[secondevt]) {
 	fPairDifference.Difference(fEvents.at(secondevt),fEvents.at(firstevt));
 	fPairDifference.Scale(0.5);
-      } else {
+      } else if (fHelicity[firstevt] == -9999 || fHelicity[secondevt]==-9999) {
+	checkhel= -9999;
+	// Helicity polarity is undefined.
+	QwDebug<<" QwHelicityPattern::CalculatePairAsymmetry == \n"
+	       <<" undefined local helicity (-9999) \n"
+	       <<" impossible to compute assymetry \n"
+	       <<" dropping every thing -- pattern number ="<<fCurrentPatternNumber<<QwLog::endl;
+	// This is an unknown helicity event.
+	fPairIsGood = kFALSE;
+      }else {
 	QwDebug << "QwHelicityPattern::CalculatePairAsymmetry:  "
-		<< "Helicity should be "<<plushel<<" or "<<minushel
-		<<" but is "<< fHelicity[firstevt] << " and " << fHelicity[secondevt]
-		<< "; Asymmetry computation aborted!"<<QwLog::endl;
+	    << "Helicity should be "<<plushel<<" or "<<minushel
+	    <<" but is "<< fHelicity[firstevt] << " and " << fHelicity[secondevt]
+	    << "; Asymmetry computation aborted!"<<QwLog::endl;
 	fPairIsGood = kFALSE;
 	// there is a different number of plus and minus helicity window.
 	QwError<<" QwHelicityPattern::CalculatePairAsymmetry == \n"

--- a/Parity/src/QwHelicityPattern.cc
+++ b/Parity/src/QwHelicityPattern.cc
@@ -82,6 +82,7 @@ QwHelicityPattern::QwHelicityPattern(QwSubsystemArrayParity &event, const TStrin
     fHelicityIsMissing(kFALSE),   
     fIgnoreHelicity(kFALSE),
     fYield(event), 
+    fDifference(event), 
     fAsymmetry(event),   
     fEnableAlternateAsym(kFALSE), 
     fAsymmetry1(event), 
@@ -100,7 +101,6 @@ QwHelicityPattern::QwHelicityPattern(QwSubsystemArrayParity &event, const TStrin
     fEnableRunningSum(kTRUE),     
     fPrintRunningSum(kFALSE),
     fEnableDifference(kFALSE),
-    fDifference(event), 
     fAlternateDiff(event),
     fPositiveHelicitySum(event), 
     fNegativeHelicitySum(event),
@@ -179,17 +179,17 @@ QwHelicityPattern::QwHelicityPattern(QwSubsystemArrayParity &event, const TStrin
 QwHelicityPattern::QwHelicityPattern(const QwHelicityPattern &source)
   : 
     fYield(source.fYield), 
+    fDifference(source.fDifference),
     fAsymmetry(source.fAsymmetry),   
     fEnableAlternateAsym(source.fEnableAlternateAsym), 
     fAsymmetry1(source.fAsymmetry1), 
     fAsymmetry2(source.fAsymmetry2),
-    fEnableRunningSum(source.fEnableRunningSum),
-    fPrintRunningSum(source.fPrintRunningSum),
-    fEnableDifference(source.fEnableDifference),
-    fDifference(source.fDifference),
     fPairYield(source.fYield), 
     fPairDifference(source.fYield),
     fPairAsymmetry(source.fYield),
+    fEnableRunningSum(source.fEnableRunningSum),
+    fPrintRunningSum(source.fPrintRunningSum),
+    fEnableDifference(source.fEnableDifference),
     fBurstYield(source.fYield), 
     fBurstDifference(source.fYield),
     fBurstAsymmetry(source.fYield),
@@ -675,6 +675,10 @@ void  QwHelicityPattern::ClearRunningSum()
     fAsymmetry1.ClearEventData();
     fAsymmetry2.ClearEventData();
   }
+  //Pair sums
+  fPairYield.ClearEventData();
+  fPairDifference.ClearEventData();
+  fPairAsymmetry.ClearEventData();
   // Running burst sums
   if (fEnableBurstSum) {
     fRunningBurstYield.ClearEventData();
@@ -733,6 +737,26 @@ void  QwHelicityPattern::AccumulateRunningSum(QwHelicityPattern &entry)
     }
   }
 }
+
+
+//*****************************************************************
+/**
+ * Accumulate the running sum for pairs by adding this helicity pattern to the
+ * running sums of yield, difference and asymmetry.
+ */
+void  QwHelicityPattern::AccumulatePairRunningSum(QwHelicityPattern &entry)
+{
+  if (entry.fPairIsGood){
+    fPairYield.AccumulateRunningSum(entry.fPairYield);
+    fPairAsymmetry.AccumulateRunningSum(entry.fPairAsymmetry);
+    if (fEnableDifference){
+      fPairDifference.AccumulateRunningSum(entry.fPairDifference);
+      // The difference is blinded, so the running difference is also blinded.
+    }
+  }
+}
+
+
 
 //*****************************************************************
 /**
@@ -794,6 +818,13 @@ void  QwHelicityPattern::CalculateRunningAverage()
     fAsymmetry1.CalculateRunningAverage();
     fAsymmetry2.CalculateRunningAverage();
   }
+  //  Pair averages
+  fPairYield.CalculateRunningAverage();
+  fPairAsymmetry.CalculateRunningAverage();
+  if (fEnableDifference){
+    fPairDifference.CalculateRunningAverage();
+  }
+
   if (fPrintRunningSum) PrintRunningAverage();
 }
 
@@ -817,19 +848,28 @@ void  QwHelicityPattern::PrintRunningBurstAverage() const
 void  QwHelicityPattern::PrintRunningAverage() const
 {
   QwMessage << "QwHelicityPattern::PrintRunningAverage() const " << QwLog::endl;
-  //  QwMessage << " Running average of yields     " << QwLog::endl;
+  QwMessage << " Running average of pattern yields     " << QwLog::endl;
   fYield.PrintValue();
-  //  QwMessage << " Running average of asymmetry  " << QwLog::endl;
+  QwMessage << " Running average of pattern asymmetries  " << QwLog::endl;
   fAsymmetry.PrintValue();
   if (fEnableAlternateAsym) {
-    //    QwMessage << " Running average of first half/second half asymmetry  "  << QwLog::endl;
+    QwMessage << " Running average of first half/second half asymmetry  "  << QwLog::endl;
     fAsymmetry1.PrintValue();
-    //    QwMessage << " Running average of even/odd asymmetry  " << QwLog::endl;
+    QwMessage << " Running average of even/odd asymmetry  " << QwLog::endl;
     fAsymmetry2.PrintValue();
   }
   if (fEnableDifference){
-    //    QwMessage << " Running average of difference " << QwLog::endl;
+    QwMessage << " Running average of pattern difference " << QwLog::endl;
     fDifference.PrintValue();
+  }
+  //Pairs
+  QwMessage << " Running average of pair yields     " << QwLog::endl;
+  fPairYield.PrintValue();
+  QwMessage << " Running average of pair asymmetries  " << QwLog::endl;
+  fPairAsymmetry.PrintValue();
+  if (fEnableDifference){
+    QwMessage << " Running average of pair difference " << QwLog::endl;
+    fPairDifference.PrintValue();
   }
 
 }


### PR DESCRIPTION
Each sequential pair of events in a pattern will have a pair yield and asymmetry calculated.  The pair based results will go into a pair tree, called "pr".  When the "print-runningsum" flag is present, the pair running sums will be printed after the pattern running sums.

This resolves issues #93 and #65.  Note to get the helicity independent asymmetries ((1-2)/(1+2)) from the "pr" tree, the asymmetry leaf should be multiplied by "(2*actual_helicity-1)" which will be  the sign of the first event of the pair:  actual_helicity==1 for Hel+ as the first event, and actual_helicity==0 for Hel- as the first event.

The "actual_helicity" variable in the mul tree is not useful, as it represents the helicity of the first Hel+ event in the pattern, so it is always 1.  The realtive polarity of the pattern is "actual_pattern_polarity", and this variable is accessible in both the mul tree and pr trees.