### PR TITLE
Implemented options -d/--data for $QW_DATA support

### DIFF
--- a/Analysis/include/QwEventBuffer.h
+++ b/Analysis/include/QwEventBuffer.h
@@ -35,6 +35,9 @@ class QwSubsystemArray;
 class QwEventBuffer: public MQwCodaControlEvent{
  public:
   static void DefineOptions(QwOptions &options);
+  static void SetDefaultDataDirectory(const std::string& dir) {
+	fDefaultDataDirectory = dir;
+  }
   static void SetDefaultDataFileStem(const std::string& stem) {
 	fDefaultDataFileStem = stem;
   }
@@ -185,6 +188,7 @@ class QwEventBuffer: public MQwCodaControlEvent{
 
  protected:
 
+  static std::string fDefaultDataDirectory;
   static std::string fDefaultDataFileStem;
   static std::string fDefaultDataFileExtension;
 

--- a/Analysis/src/QwEventBuffer.cc
+++ b/Analysis/src/QwEventBuffer.cc
@@ -26,6 +26,7 @@ void sigint_handler(int sig)
 #include "THaEtClient.h"
 #endif
 
+std::string QwEventBuffer::fDefaultDataDirectory = "/adaq1/data1/apar";
 std::string QwEventBuffer::fDefaultDataFileStem = "QwRun_";
 std::string QwEventBuffer::fDefaultDataFileExtension = "log";
 
@@ -43,6 +44,7 @@ QwEventBuffer::QwEventBuffer()
   :    fRunListFile(NULL),
        fDataFileStem(fDefaultDataFileStem),
        fDataFileExtension(fDefaultDataFileExtension),
+       fDataDirectory(fDefaultDataDirectory),
        fEvStreamMode(fEvStreamNull),
        fEvStream(NULL),
        fCurrentRun(-1),
@@ -56,14 +58,6 @@ QwEventBuffer::QwEventBuffer()
   signal(SIGINT,  sigint_handler);// ctrl+c
   signal(SIGTERM, sigint_handler);// kill in shell // 15
   //  signal(SIGTSTP, sigint_handler);// ctrl+z // 20
-
-  fDataDirectory = getenv_safe("QW_DATA");
-  if (fDataDirectory.Length() == 0){
-    QwError << "ERROR:  Can't get the data directory in the QwEventBuffer creator."
-	    << QwLog::endl;
-  } else if (! fDataDirectory.EndsWith("/")) {
-      fDataDirectory.Append("/");
-  }
 
   fCleanParameter[0] = 0.0;
   fCleanParameter[1] = 0.0;
@@ -88,6 +82,9 @@ void QwEventBuffer::DefineOptions(QwOptions &options)
   options.AddDefaultOptions()
     ("run,r", po::value<string>()->default_value("0:0"),
      "run range in format #[:#]");
+  options.AddDefaultOptions()
+    ("data,d", po::value<string>()->default_value(fDefaultDataDirectory),
+     "data directory, also $QW_DATA");
   options.AddDefaultOptions()
     ("runlist", po::value<string>()->default_value(""),
      "run list file name");
@@ -166,6 +163,15 @@ void QwEventBuffer::ProcessOptions(QwOptions &options)
     }
 #endif
   }
+
+  fDataDirectory = options.GetValue<string>("data");
+  if (fDataDirectory.Length() == 0){
+    QwError << "ERROR:  Can't get the data directory in the QwEventBuffer creator."
+	    << QwLog::endl;
+  } else if (! fDataDirectory.EndsWith("/")) {
+      fDataDirectory.Append("/");
+  }
+
   fRunRange = options.GetIntValuePair("run");
   fEventRange = options.GetIntValuePair("event");
   fSegmentRange = options.GetIntValuePair("segment");

--- a/Analysis/src/QwOptions.cc
+++ b/Analysis/src/QwOptions.cc
@@ -262,9 +262,27 @@ void QwOptions::ParseCommandLine()
  */
 void QwOptions::ParseEnvironment()
 {
+  class name_mapper {
+    public:
+      name_mapper(const std::string& prefix, const std::string& ignore)
+      : prefix(prefix),ignore(ignore) { }
+      std::string operator()(const std::string& s) {
+        string lc;
+        if (s.find(prefix) == 0) {
+          for(string::size_type n = prefix.size(); n < s.size(); ++n) {
+            lc += static_cast<char>(tolower(s[n]));
+          }
+        }
+        if (ignore.find(lc) == std::string::npos) return lc;
+        else return "";
+      }
+  private:
+    std::string prefix, ignore;
+  } qw_name_mapper("QW_", "bin fieldmap lib lookup prminput rootfiles searchtree tmp");
+
   try {
     po::options_description* environment_options = CombineOptions();
-    po::store(po::parse_environment(*environment_options, "Qw"), fVariablesMap);
+    po::store(po::parse_environment(*environment_options, qw_name_mapper), fVariablesMap);
     delete environment_options;
   } catch (std::exception const& e) {
     QwWarning << e.what() << " while parsing environment variables" << QwLog::endl;


### PR DESCRIPTION
QwEventBuffer is the only class using $QW_DATA env var support. Now we
have a static default data directory ("/adaq1/data1/apar") which is
overriden by QW_DATA or -d/--data.

QwOptions was slightly modified in its env var parsing. Instead of
requiring a prefix "Qw" (i.e. Qwrun=100 is equivalent to --run=100) it
now uses "QW_" as prefix.

Unfortunately boost::program_options::parse_environment does not allow
for the "allow_unregistered()" decorator, so we immediately trip up over
the unparsed $QW_FIELDMAP and the like. We bypass this problem by
writing a functor to which we can specify a set of lowercase appendages
to ignore (e.g. "fieldmap"). The rest the functor does it stripping the
prefix "QW_" and turning the rest to lowercase for parsing "QW_DATA" as
"data" and then recognizing as the argument of --data.

tl;dr
```
build/qwparity_simple -r 10 -d /my/data/path
QW_DATA=/your/data/path build/qwparity_simple -r 10 -d /my/data/path
QW_DATA=/my/data/path build/qwparity_simple -r 10
```
now all have the same result.

Notes on the PR:
- Needs testing on older boost versions. Not sure of the need for preprocessor guards based on the functor functionality. I think that's been there for long enough though.
- Might make sense to fold in QW_PRMINPUT parsing in QwParameterFile, but I remember that for some reason QwOptions and QwParameterFile could not depend on each other.