### PR TITLE
Added a new config parameter saturation limit for integration PMT

### DIFF
--- a/Parity/include/QwIntegrationPMT.h
+++ b/Parity/include/QwIntegrationPMT.h
@@ -101,6 +101,7 @@ void RandomizeMollerEvent(int helicity, const QwBeamCharge& charge, const QwBeam
   /*! \brief Inherited from VQwDataElement to set the upper and lower limits (fULimit and fLLimit), stability % and the error flag on this channel */
   void SetSingleEventCuts(UInt_t errorflag, Double_t LL, Double_t UL, Double_t stability);
   void SetDefaultSampleSize(Int_t sample_size);
+  void SetSaturationLimit(Double_t saturation_volt );
   UInt_t GetEventcutErrorFlag(){//return the error flag
     return fTriumf_ADC.GetEventcutErrorFlag();
   }

--- a/Parity/src/QwDetectorArray.cc
+++ b/Parity/src/QwDetectorArray.cc
@@ -174,8 +174,8 @@ Int_t QwDetectorArray::LoadChannelMap(TString mapfile)
   Int_t wordsofar=0;
   Int_t currentsubbankindex=-1;
   Int_t sample_size=0;
-
-
+  Double_t abs_saturation_limit = 8.5; // default saturation limit(volt)
+  Bool_t bAssignedLimit = kFALSE;
 
   // Open the file
   QwParameterFile mapstr(mapfile.Data());
@@ -191,6 +191,10 @@ Int_t QwDetectorArray::LoadChannelMap(TString mapfile)
   while (mapstr.ReadNextLine())
     {
       RegisterRocBankMarker(mapstr);
+      if (mapstr.PopValue("abs_saturation_limit",value)) {
+	abs_saturation_limit=value;
+	bAssignedLimit = kTRUE;
+      }
       if (mapstr.PopValue("sample_size",value)) {
 	sample_size=value;
       }
@@ -317,6 +321,8 @@ Int_t QwDetectorArray::LoadChannelMap(TString mapfile)
 		  	localIntegrationPMT.SetNormalizability(kTRUE);
 		  fIntegrationPMT.push_back(localIntegrationPMT);
                   fIntegrationPMT[fIntegrationPMT.size()-1].SetDefaultSampleSize(sample_size);
+		  if(bAssignedLimit)
+		    fIntegrationPMT[fIntegrationPMT.size()-1].SetSaturationLimit(abs_saturation_limit);
 		  localMainDetID.fIndex=fIntegrationPMT.size()-1;
                 }
 

--- a/Parity/src/QwIntegrationPMT.cc
+++ b/Parity/src/QwIntegrationPMT.cc
@@ -221,6 +221,11 @@ void QwIntegrationPMT::SetSingleEventCuts(UInt_t errorflag, Double_t LL=0, Doubl
 void QwIntegrationPMT::SetDefaultSampleSize(Int_t sample_size){
  fTriumf_ADC.SetDefaultSampleSize((size_t)sample_size);
 }
+
+/********************************************************/
+void QwIntegrationPMT::SetSaturationLimit(Double_t saturation_volt){
+  fTriumf_ADC.SetVQWKSaturationLimt(saturation_volt);
+}
 //*/
 
 /********************************************************/


### PR DESCRIPTION
Optional parameter for setting saturation limit to integration PMTs.
By default, the 8.5 volt limit is initialized by QwVQWK_Channel constructor [Line 66 ](https://github.com/JeffersonLab/japan/blob/cdd64b4dc958b722b001ca87d451e3791bbec190/Analysis/include/QwVQWK_Channel.h#L66).
 The new parameter will overwrite the default value if it is specified in the detector map. 