### PR TITLE
Changed QW_ROOTFILES into QwOptions variable

### DIFF
--- a/Analysis/include/QwRootFile.h
+++ b/Analysis/include/QwRootFile.h
@@ -296,6 +296,10 @@ class QwRootFile {
     static void DefineOptions(QwOptions &options);
     /// \brief Process the configuration options
     void ProcessOptions(QwOptions &options);
+    /// \brief Set default ROOT files dir
+    static void SetDefaultRootFileDir(const std::string& dir) {
+      fDefaultRootFileDir = dir;
+    }
     /// \brief Set default ROOT file stem
     static void SetDefaultRootFileStem(const std::string& stem) {
       fDefaultRootFileStem = stem;
@@ -472,6 +476,11 @@ class QwRootFile {
 
     /// ROOT file
     TFile* fRootFile;
+
+    /// ROOT files dir
+    TString fRootFileDir;
+    /// Default ROOT files dir
+    static std::string fDefaultRootFileDir;
 
     /// ROOT file stem
     TString fRootFileStem;

--- a/Analysis/src/QwPromptSummary.cc
+++ b/Analysis/src/QwPromptSummary.cc
@@ -500,7 +500,7 @@ void
 QwPromptSummary::PrintCSV()
 {
   printf("-----------------------\n");
-  TString filename = getenv_safe_TString("QW_ROOTFILES"); 
+  TString filename = gQwOptions.GetValue<std::string>("rootfiles");
   filename+=Form("/summary_%d.txt", fRunNumber);
   TString header= this->PrintCSVHeader();
   std::ofstream output;

--- a/Analysis/src/QwRootFile.cc
+++ b/Analysis/src/QwRootFile.cc
@@ -5,6 +5,7 @@
 #include <unistd.h>
 #include <cstdio>
 
+std::string QwRootFile::fDefaultRootFileDir = ".";
 std::string QwRootFile::fDefaultRootFileStem = "Qweak_";
 
 const Long64_t QwRootFile::kMaxTreeSize = 100000000000LL;
@@ -20,18 +21,11 @@ QwRootFile::QwRootFile(const TString& run_label)
 {
   // Process the configuration options
   ProcessOptions(gQwOptions);
-  
+
   // Check for the memory-mapped file flag
   if (fEnableMapFile) {
-    
+
     TString mapfilename = "/dev/shm/";
-    
-    // if( host_name.Contains("cdaql4") and (not user_name.CompareTo("cdaq", TString::kExact)) ) {
-    //   mapfilename = "/local/scratch/qweak/";
-    // }
-    // else {
-    //   mapfilename = getenv_safe_TString("QW_ROOTFILES");
-    // }
 
     mapfilename += "/QwMemMapFile.map";
 
@@ -49,28 +43,8 @@ QwRootFile::QwRootFile(const TString& run_label)
 
   } else {
 
-    //TString rootfilename = getenv_safe_TString("QW_ROOTFILES");
+    TString rootfilename = fRootFileDir;
     TString hostname = gSystem -> HostName();
-    TString rootfilename;
-    TString localRootFileName = gSystem->Getenv("QW_ROOTFILES_LOCAL");
-
-//     std::cout << "---------------------------------------------------------------------------------" << std::endl;
-//     printf("\n\n\n\n\n\n");
-//     printf("%s %s \n", hostname.Data(), localRootFileName.Data());
-//     printf("\n\n\n\n\n\n");
-//     std::cout << "---------------------------------------------------------------------------------" << std::endl;
-//     //    if( localRootFileName.CompareTo("") == 0 ) {
-    if (localRootFileName.IsNull()) {
-        rootfilename = getenv_safe_TString("QW_ROOTFILES");
-    } else {
-        rootfilename = localRootFileName;
-    }
-//     std::cout << "---------------------------------------------------------------------------------" << std::endl;
-//     printf("\n\n\n\n\n\n");
-//     printf("%s %s \n", hostname.Data(), localRootFileName.Data());
-//     printf("\n\n\n\n\n\n");
-//     std::cout << "---------------------------------------------------------------------------------" << std::endl;
-
 
     // Use a probably-unique temporary file name.
     pid_t pid = getpid();
@@ -169,6 +143,11 @@ QwRootFile::~QwRootFile()
  */
 void QwRootFile::DefineOptions(QwOptions &options)
 {
+  // Define the ROOT files directory
+  options.AddOptions("Default options")
+    ("rootfiles", po::value<std::string>()->default_value(fDefaultRootFileDir),
+     "directory of the output ROOT files");
+
   // Define the ROOT filename stem
   options.AddOptions("Default options")
     ("rootfile-stem", po::value<std::string>()->default_value(fDefaultRootFileStem),
@@ -243,6 +222,9 @@ void QwRootFile::DefineOptions(QwOptions &options)
  */
 void QwRootFile::ProcessOptions(QwOptions &options)
 {
+  // Option 'rootfiles' to specify ROOT files dir
+  fRootFileDir = TString(options.GetValue<std::string>("rootfiles"));
+
   // Option 'root-stem' to specify ROOT file stem
   fRootFileStem = TString(options.GetValue<std::string>("rootfile-stem"));
 


### PR DESCRIPTION
Now `qwparity --rootfiles <dir>` is (or should be) equivalent to `QW_ROOTFILES=<dir> qwparity`. The default rootfiles directory is `.` but even that can be changed (before defining the QwRootFile option) by calling QwRootFile::SetDefaultRootFileDir().

Removed QW_ROOTFILES_LOCAL since not necessary if this environment
variable can be overridden in many several ways now (in qwparity.conf
and on command line, in that order of override power).

QwPromptSummary uses QW_ROOTFILES and should pick up the right value too.