### PR TITLE
Explicitly add the panguin "macros" subdirectory to the gROOT macro search path

### DIFF
--- a/panguin/panguin.cc
+++ b/panguin/panguin.cc
@@ -20,6 +20,10 @@ int main(int argc, char **argv){
   Bool_t showedUsage=kFALSE;
   int verbosity(0);
 
+  TString macropath = gROOT->GetMacroPath();
+  macropath += ":./macros";
+  gROOT->SetMacroPath(macropath.Data());
+
   TApplication theApp("App",&argc,argv,NULL,-1);
 
   cout<<"Starting processing arg. Time passed: "


### PR DESCRIPTION
This way we do not depend upon the root macro search path being defined properly in the .rootrc file.