### PR TITLE
Feature: set of ConstructObjects methods to store arbitrary TObjects once

### DIFF
--- a/Analysis/include/QwRootFile.h
+++ b/Analysis/include/QwRootFile.h
@@ -331,6 +331,10 @@ class QwRootFile {
 
     /// \brief Construct the histograms of a generic object
     template < class T >
+    void ConstructObjects(const std::string& name, T& object);
+
+    /// \brief Construct the histograms of a generic object
+    template < class T >
     void ConstructHistograms(const std::string& name, T& object);
     /// Fill histograms of the subsystem array
     template < class T >
@@ -724,6 +728,37 @@ void QwRootFile::FillTreeBranches(
   // Fill the trees with the correct address
   for (size_t tree = 0; tree < fTreeByAddr[addr].size(); tree++) {
     fTreeByAddr[addr].at(tree)->FillTreeBranches(object);
+  }
+}
+
+
+/**
+ * Construct the objects directory of a generic object
+ * @param name Name for objects directory
+ * @param object Subsystem array
+ */
+template < class T >
+void QwRootFile::ConstructObjects(const std::string& name, T& object)
+{
+  // Create the objects in a directory
+  if (fRootFile) {
+    std::string type = typeid(object).name();
+    fDirsByName[name] = fRootFile->GetDirectory("/")->mkdir(name.c_str());
+    fDirsByType[type].push_back(name);
+    object.ConstructObjects(fDirsByName[name]);
+  }
+
+  // No support for directories in a map file
+  if (fMapFile) {
+    QwMessage << "QwRootFile::ConstructObjects::detectors address "
+	      << &object
+	      << " and its name " << name
+	      << QwLog::endl;
+
+    std::string type = typeid(object).name();
+    fDirsByName[name] = fMapFile->GetDirectory()->mkdir(name.c_str());
+    fDirsByType[type].push_back(name);
+    object.ConstructObjects();
   }
 }
 

--- a/Analysis/include/QwSubsystemArray.h
+++ b/Analysis/include/QwSubsystemArray.h
@@ -192,6 +192,22 @@ class QwSubsystemArray:  public std::vector<boost::shared_ptr<VQwSubsystem> > {
 
  public:
 
+  /// \name Object construction and maintenance
+  // @{
+  /// Construct the objects for this subsystem
+  void  ConstructObjects() {
+    ConstructObjects((TDirectory*) NULL);
+  };
+  /// Construct the objects for this subsystem in a folder
+  void  ConstructObjects(TDirectory *folder) {
+    TString prefix = "";
+    ConstructObjects(folder, prefix);
+  };
+  /// \brief Construct the objects for this subsystem in a folder with a prefix
+  void  ConstructObjects(TDirectory *folder, TString &prefix);
+  // @}
+
+
   /// \name Histogram construction and maintenance
   // @{
   /// Construct the histograms for this subsystem

--- a/Analysis/include/VQwSubsystem.h
+++ b/Analysis/include/VQwSubsystem.h
@@ -204,6 +204,27 @@ class VQwSubsystem: virtual public VQwSubsystemCloneable, public MQwHistograms {
   virtual void  EncodeEventData(std::vector<UInt_t> &buffer) { };
 
 
+  /// \name Objects construction and maintenance
+  // @{
+  /// Construct the objects for this subsystem
+  virtual void  ConstructObjects() {
+    TString tmpstr("");
+    ConstructObjects((TDirectory*) NULL, tmpstr);
+  };
+  /// Construct the objects for this subsystem in a folder
+  virtual void  ConstructObjects(TDirectory *folder) {
+    TString tmpstr("");
+    ConstructObjects(folder, tmpstr);
+  };
+  /// Construct the objects for this subsystem with a prefix
+  virtual void  ConstructObjects(TString &prefix) {
+    ConstructObjects((TDirectory*) NULL, prefix);
+  };
+  /// \brief Construct the objects for this subsystem in a folder with a prefix
+  virtual void  ConstructObjects(TDirectory *folder, TString &prefix) { };
+  // @}
+
+
   /// \name Histogram construction and maintenance
   // @{
   /// Construct the histograms for this subsystem

--- a/Analysis/src/QwSubsystemArray.cc
+++ b/Analysis/src/QwSubsystemArray.cc
@@ -406,6 +406,16 @@ void  QwSubsystemArray::EncodeEventData(std::vector<UInt_t> &buffer)
 
 
 //*****************************************************************
+void  QwSubsystemArray::ConstructObjects(TDirectory *folder, TString &prefix)
+{
+  if (!empty()) {
+    for (iterator subsys = begin(); subsys != end(); ++subsys){
+      (*subsys)->ConstructObjects(folder,prefix);
+    }
+  }
+}
+
+//*****************************************************************
 void  QwSubsystemArray::ConstructHistograms(TDirectory *folder, TString &prefix)
 {
   if (!empty()) {

--- a/Parity/include/QwBlinder.h
+++ b/Parity/include/QwBlinder.h
@@ -213,9 +213,12 @@ class QwBlinder {
 
     void ConstructObjects(TDirectory *folder, TString &prefix) {
       if (folder != NULL) folder->cd();
-      TString basename = prefix + "seed";
-      const TObjString* data = new TObjString(fSeed);
-      folder->WriteTObject(data, basename.Data());
+      const TObjString* seed = new TObjString(fSeed);
+      folder->WriteTObject(seed, prefix + "seed", "WriteDelete");
+      const TObjString* seedID = new TObjString(Form("%u",fSeedID));
+      folder->WriteTObject(seedID, prefix + "seedID", "WriteDelete");
+      const TObjString* strategy = new TObjString(Form("%u", fBlindingStrategy));
+      folder->WriteTObject(strategy, prefix + "strategy", "WriteDelete");
     };
 
  private:

--- a/Parity/include/QwBlinder.h
+++ b/Parity/include/QwBlinder.h
@@ -211,6 +211,13 @@ class QwBlinder {
 
     const Bool_t& IsBlinderOkay() const {return fBlinderIsOkay;};
 
+    void ConstructObjects(TDirectory *folder, TString &prefix) {
+      if (folder != NULL) folder->cd();
+      TString basename = prefix + "seed";
+      const TObjString* data = new TObjString(fSeed);
+      folder->WriteTObject(data, basename.Data());
+    };
+
  private:
     ///  Indicates the first value recieved of the blindability of the target 
     EQwBlinderStatus fTargetBlindability_firstread;

--- a/Parity/include/QwHelicityPattern.h
+++ b/Parity/include/QwHelicityPattern.h
@@ -133,6 +133,9 @@ class QwHelicityPattern {
   void  PrintRunningAverage() const;
   void  PrintBurstAverage() const;
 
+  void  ConstructObjects(){ConstructObjects((TDirectory*)NULL);};
+  void  ConstructObjects(TDirectory *folder);
+
   void  ConstructHistograms(){ConstructHistograms((TDirectory*)NULL);};
   void  ConstructHistograms(TDirectory *folder);
   void  FillHistograms();

--- a/Parity/main/QwParity_simple.cc
+++ b/Parity/main/QwParity_simple.cc
@@ -328,8 +328,11 @@ Int_t main(Int_t argc, Char_t* argv[])
       QwMessage << " =========================" << QwLog::endl;
       runningsum.PrintValue();
     }
-   
-  
+
+
+    //  Construct objects
+    treerootfile->ConstructObjects("objects", helicitypattern);
+
     /*  Write to the root file, being sure to delete the old cycles  *
      *  which were written by Autosave.                              *
      *  Doing this will remove the multiple copies of the ntuples    *

--- a/Parity/src/QwHelicityPattern.cc
+++ b/Parity/src/QwHelicityPattern.cc
@@ -883,6 +883,29 @@ void  QwHelicityPattern::PrintBurstAverage() const
 }
 
 //*****************************************************************
+void  QwHelicityPattern::ConstructObjects(TDirectory *folder)
+{
+  TString prefix = "blinder_";
+  fBlinder.ConstructObjects(folder,prefix);
+
+  prefix = "yield_";
+  fYield.ConstructObjects(folder,prefix);
+  prefix = "asym_";
+  fAsymmetry.ConstructObjects(folder,prefix);
+
+  if (fEnableDifference) {
+    prefix = "diff_";
+    fDifference.ConstructObjects(folder,prefix);
+  }
+  if (fEnableAlternateAsym) {
+    prefix = "asym1_";
+    fAsymmetry1.ConstructObjects(folder,prefix);
+    prefix = "asym2_";
+    fAsymmetry2.ConstructObjects(folder,prefix);
+  }
+}
+
+//*****************************************************************
 void  QwHelicityPattern::ConstructHistograms(TDirectory *folder)
 {
   TString prefix = "yield_";


### PR DESCRIPTION
In similar vein (and maybe in vain too) to the `ConstructHistograms` and `ConstructBranchAndTreeVector` this provides another interface to the ROOT file, but it is only supposed to be called once. Probably that means at the beginning or at the end of the ROOT file, depending on what you use it for (beginning if you write configuration and want to ensure data is saved also when run crashes; end if you write summary information for the entire run, like running sums etc).

Possible modifications:
- [x] Use kOverwrite or kWriteOnce to deal with calling this method more than once