### PR TITLE
Construct unit branch in every tree

### DIFF
--- a/Analysis/include/QwRootFile.h
+++ b/Analysis/include/QwRootFile.h
@@ -61,6 +61,9 @@ class QwRootTree {
       // Construct tree
       ConstructNewTree();
 
+      // Construct branch
+      ConstructUnitsBranch();
+
       // Construct branches and vector
       ConstructBranchAndVector(object);
     }
@@ -83,10 +86,18 @@ class QwRootTree {
 
   private:
 
+    static const TString kUnitsName;
+    static Double_t kUnitsValue[];
+
     /// Construct the tree
     void ConstructNewTree() {
       QwMessage << "New tree: " << fName << ", " << fDesc << QwLog::endl;
       fTree = new TTree(fName.c_str(), fDesc.c_str());
+    }
+
+    void ConstructUnitsBranch() {
+      std::string name = "units";
+      fTree->Branch(name.c_str(), &kUnitsValue, kUnitsName);
     }
 
     /// Construct index from this tree to another tree

--- a/Analysis/src/QwRootFile.cc
+++ b/Analysis/src/QwRootFile.cc
@@ -11,6 +11,9 @@ std::string QwRootFile::fDefaultRootFileStem = "Qweak_";
 const Long64_t QwRootFile::kMaxTreeSize = 100000000000LL;
 const Int_t QwRootFile::kMaxMapFileSize = 0x3fffffff; // 1 GiB
 
+const TString QwRootTree::kUnitsName = "ppm/D:ppb/D:um/D:mm/D";
+Double_t QwRootTree::kUnitsValue[] = { 1e-6, 1e-9, 1e-3, 1 };
+
 /**
  * Constructor with relative filename
  */


### PR DESCRIPTION
With `"ppm/D:ppb/D:um/D:mm/D" = { 1e-6, 1e-9, 1e-3, 1 }` one can now
plot things like `mul->Draw("asym_qwk_mdallbars/ppb")` or
`mul->Draw("diff_qwk_xtarg/um")`.

`mul->Print()` indicates that there is hardly an impact on size since
our event size is large and constants compress well. Someone should
evaluate in real-world environment, though.