### PR TITLE
Allow for prefix = set1_ flags in data handlers

### DIFF
--- a/Parity/include/VQwDataHandler.h
+++ b/Parity/include/VQwDataHandler.h
@@ -37,7 +37,7 @@ class VQwDataHandler:  virtual public VQwDataHandlerCloneable {
     typedef std::vector< VQwHardwareChannel* >::iterator Iterator_HdwChan;
     typedef std::vector< VQwHardwareChannel* >::const_iterator ConstIterator_HdwChan;
 
-    VQwDataHandler(const TString& name):fName(name),fKeepRunningSum(kFALSE){}
+    VQwDataHandler(const TString& name):fName(name),fPrefix(""),fKeepRunningSum(kFALSE) {}
     VQwDataHandler(const VQwDataHandler &source);
 
     virtual void ParseConfigFile(QwParameterFile& file);
@@ -109,6 +109,8 @@ class VQwDataHandler:  virtual public VQwDataHandlerCloneable {
    std::string fMapFile;
    std::string fTreeName;
    std::string fTreeComment;
+
+   std::string fPrefix;
 
    TString run_label;
 

--- a/Parity/src/VQwDataHandler.cc
+++ b/Parity/src/VQwDataHandler.cc
@@ -224,9 +224,7 @@ void VQwDataHandler::ConstructBranchAndVector(
     std::vector<Double_t>& values)
 {
   for (size_t i = 0; i < fOutputVar.size(); ++i) {
-    TString fullprefix(fPrefix);
-    fullprefix += prefix;
-    fOutputVar.at(i)->ConstructBranchAndVector(tree, fullprefix, values);
+    fOutputVar.at(i)->ConstructBranchAndVector(tree, prefix, values);
   }
 }
 

--- a/Parity/src/VQwDataHandler.cc
+++ b/Parity/src/VQwDataHandler.cc
@@ -38,6 +38,7 @@ VQwDataHandler::VQwDataHandler(const VQwDataHandler &source):
   fMapFile(source.fMapFile),
   fTreeName(source.fTreeName),
   fTreeComment(source.fTreeComment),
+  fPrefix(source.fPrefix),
   fKeepRunningSum(source.fKeepRunningSum)
 {
   fDependentVar  = source.fDependentVar;
@@ -75,6 +76,7 @@ void VQwDataHandler::ParseConfigFile(QwParameterFile& file){
   file.PopValue("priority",fPriority);
   file.PopValue("tree-name",fTreeName);
   file.PopValue("tree-comment",fTreeComment);
+  file.PopValue("prefix",fPrefix);
 }
 
 
@@ -212,7 +214,7 @@ pair<VQwDataHandler::EQwHandleType,string> VQwDataHandler::ParseHandledVariable(
 void VQwDataHandler::ConstructTreeBranches(QwRootFile *treerootfile)
 {
   if (fTreeName.size()>0){
-    treerootfile->ConstructTreeBranches(fTreeName, fTreeComment, *this);
+    treerootfile->ConstructTreeBranches(fTreeName, fTreeComment, *this, fPrefix);
   }
 }
 
@@ -222,7 +224,9 @@ void VQwDataHandler::ConstructBranchAndVector(
     std::vector<Double_t>& values)
 {
   for (size_t i = 0; i < fOutputVar.size(); ++i) {
-    fOutputVar.at(i)->ConstructBranchAndVector(tree, prefix, values);
+    TString fullprefix(fPrefix);
+    fullprefix += prefix;
+    fOutputVar.at(i)->ConstructBranchAndVector(tree, fullprefix, values);
   }
 }
 


### PR DESCRIPTION
This will prepend to the name of leafs in the tree, and should
allow for having multiple correlator sets run simultaneously.

E.g. prefix = kitchensink_ could be everything, while empty
prefix could be the default regression set.

Also works for other data handlers e.g. correctors.

TODO list:
- [x] test :-)
