### PR TITLE
Support for event ranges like `-e :10k`

### DIFF
--- a/Analysis/include/QwParameterFile.h
+++ b/Analysis/include/QwParameterFile.h
@@ -270,6 +270,8 @@ class QwParameterFile {
     /// \brief Parse a range of integers as #:# where either can be missing
     static std::pair<int,int> ParseIntRange(const std::string& separatorchars, const std::string& range);
 
+    /// \brief Parse an integer as #[kM] with optional metric scale factor
+    static int ParseInt(const std::string& value);
 
   protected:
 


### PR DESCRIPTION
In all parsed integer ranges (with ParseIntRange) we now use ParseInt
which also knows about k = 1e3 and M = 1e6. So, now we can do
```
build/qwparity -c prex.conf -r 1296 -e :10k
```
to run the first 10k events. Other options: `-e 1k:` for all events
starting at 1k to end of run. Also works on run ranges, which probably
no one uses.

What doesn't work? 1.5k and the like. Keep it integer.