### PR TITLE
Fix the regalias file that LRB creates.

### DIFF
--- a/Parity/src/QwCorrelator.cc
+++ b/Parity/src/QwCorrelator.cc
@@ -104,7 +104,7 @@ void QwCorrelator::CalcCorrelations()
 
   TString outAlphas=Form(tmp.c_str());
   corA.exportAlphas(outAlphas, fIndependentFull, fDependentFull);
-  corA.exportAlias(fAliasOutputPath, "/regalias_"+run_label, fIndependentFull, fDependentFull);
+  corA.exportAlias(fAliasOutputPath + "/", "regalias_"+run_label, fIndependentFull, fDependentFull);
 
 }
 

--- a/Parity/src/QwkRegBlueCorrelator.cc
+++ b/Parity/src/QwkRegBlueCorrelator.cc
@@ -231,9 +231,10 @@ QwkRegBlueCorrelator::exportAlias(TString outPath, TString macroName,std::vector
 
  
   FILE *fd=fopen(outPath+macroName+".C","w");
-  fprintf(fd,"%s() {\n",macroName.Data());
+  fprintf(fd,"void %s() {\n",macroName.Data());
+  fprintf(fd,"  TTree* tree = (TTree*) gDirectory->Get(\"mul\");\n");
   for (int iy = 0; iy <nY; iy++) {
-    fprintf(fd,"  Hel_Tree->SetAlias(\"reg_%s\",\n         \"%s",Yname[iy].Data(),Yname[iy].Data());
+    fprintf(fd,"  tree->SetAlias(\"reg_%s\",\n         \"%s",Yname[iy].Data(),Yname[iy].Data());
     for (int j = 0; j < nP; j++) {
       double val= -linReg.mA(j,iy);
       if(val>0)  fprintf(fd,"+");


### PR DESCRIPTION
Previously not loadable since function name start with slash, no
return type, uses undefined locals.

Now proper void, no slash, gets "mul" from current directory of
ROOT file i.e. loads `.x regalias_1296.C` works now.

Does anyone use this file? If not, then consider this immediately obsolete... If so, let me know how whether if this ever worked?