### PR TITLE
Also store objects in the QwParity executable, not just simple one.

### DIFF
--- a/Parity/main/QwParity.cc
+++ b/Parity/main/QwParity.cc
@@ -380,8 +380,11 @@ Int_t main(Int_t argc, Char_t* argv[])
       QwMessage << " =========================" << QwLog::endl;
       runningsum.PrintValue();
     }
-   
-  
+
+
+    //  Construct objects
+    treerootfile->ConstructObjects("objects", helicitypattern);
+
     /*  Write to the root file, being sure to delete the old cycles  *
      *  which were written by Autosave.                              *
      *  Doing this will remove the multiple copies of the ntuples    *


### PR DESCRIPTION
This is a follow-up of #121 which only stored the blinder status objects when using the QwParity_simple executable.