### PR TITLE
QwRootFile uses TDirectory::mkdir which returns 0 if already exists

### DIFF
--- a/Analysis/include/QwRootFile.h
+++ b/Analysis/include/QwRootFile.h
@@ -743,7 +743,10 @@ void QwRootFile::ConstructObjects(const std::string& name, T& object)
   // Create the objects in a directory
   if (fRootFile) {
     std::string type = typeid(object).name();
-    fDirsByName[name] = fRootFile->GetDirectory("/")->mkdir(name.c_str());
+    fDirsByName[name] =
+        fRootFile->GetDirectory(("/" + name).c_str()) ?
+            fRootFile->GetDirectory(("/" + name).c_str()) :
+            fRootFile->GetDirectory("/")->mkdir(name.c_str());
     fDirsByType[type].push_back(name);
     object.ConstructObjects(fDirsByName[name]);
   }
@@ -777,7 +780,10 @@ void QwRootFile::ConstructHistograms(const std::string& name, T& object)
   // Create the histograms in a directory
   if (fRootFile) {
     std::string type = typeid(object).name();
-    fDirsByName[name] = fRootFile->GetDirectory("/")->mkdir(name.c_str());
+    fDirsByName[name] =
+        fRootFile->GetDirectory(("/" + name).c_str()) ?
+            fRootFile->GetDirectory(("/" + name).c_str()) :
+            fRootFile->GetDirectory("/")->mkdir(name.c_str());
     fDirsByType[type].push_back(name);
     object.ConstructHistograms(fDirsByName[name]);
   }
@@ -788,7 +794,7 @@ void QwRootFile::ConstructHistograms(const std::string& name, T& object)
 	      << &object  
 	      << " and its name " << name 
 	      << QwLog::endl;
-    
+
     std::string type = typeid(object).name();
     fDirsByName[name] = fMapFile->GetDirectory()->mkdir(name.c_str());
     fDirsByType[type].push_back(name);


### PR DESCRIPTION
So, we first check for the directory and use it if it exists. Otherwise we create it and use that one.

This fixes a bug in https://github.com/JeffersonLab/japan/tree/feature-pure-mixin-root-iface which causes the mixin implementation of storing object to not work as intended. With this bugfix it does work as intended. The bugfix is relevant outside the branch too, though, even if we have not run into it.