### PR TITLE
Return an actual int in functions returning int [-Wreturn-type]

### DIFF
--- a/Parity/src/LRBCorrector.cc
+++ b/Parity/src/LRBCorrector.cc
@@ -105,7 +105,8 @@ Int_t LRBCorrector::LoadChannelMap(const std::string& mapfile)
   //printf("opened %s, slopes found, dump:\n",corFile->GetName());
   //alphasM->Print();
   corFile->Close();
-  
+
+  return 0;
 }
 
 
@@ -146,6 +147,7 @@ Int_t LRBCorrector::ConnectChannels(
   QwMessage << "In LRBCorrector::ConnectChannels; Number of IVs: " << fIndependentVar.size()
             << " Number of DVs: " << fDependentVar.size() << QwLog::endl;
 
+  return 0;
 }
 
 

--- a/Parity/src/QwCorrelator.cc
+++ b/Parity/src/QwCorrelator.cc
@@ -163,6 +163,7 @@ Int_t QwCorrelator::LoadChannelMap(const std::string& mapfile)
   //QwMessage << "fDependentType has a size of: " << fDependentType.size() << QwLog::endl;
   //QwMessage << "fDependentName has a size of: " << fDependentName.size() << QwLog::endl;
 
+  return 0;
 }
 
 
@@ -275,7 +276,6 @@ Int_t QwCorrelator::ConnectChannels(QwSubsystemArrayParity& asym, QwSubsystemArr
   fErrCounts_DV.resize(fDependentVar.size(),0);
 
   return 0;
-	
 }
 
 


### PR DESCRIPTION
This actually causes crashes with gcc-8.3 when a calling function
directly uses the returned value itself in a return. In particular:
```
#include <iostream>

class A {
  public:
    int f(int i) { return this->f(i,i); };
    virtual int f(int,int) { return 0; };
};

class B: public A {
  public:
    int f(int,int) { /* ERROR HERE */ };
};

int main() {
  B* b = new B();
  A* a = b;
  std::cout << a->f(1) << std::endl;
}
```
when compiled as `g++ -o test -O2 test.cpp` (with warnings!) crashes with
```
Segmentation fault (core dumped)
```
Something a tiny bit more involved happens in japaan. I suspect this is
because of the different behavior of temporaries when returned (constexpr)
since the caller thinks it can evaluate the return value at compile time,
but in practice it fails since there is no temporary to return.

tl;dr
Don't ignore the warnings, please! This is why we can't have nice things.

@paulmking This was why japan crashed on my laptop. Issue now fixed.