### PR TITLE
Added QwRootfile option to disable the use of the "temporary" rootfile.

### DIFF
--- a/Analysis/include/QwRootFile.h
+++ b/Analysis/include/QwRootFile.h
@@ -482,6 +482,7 @@ class QwRootFile {
     /// change to a permanent name when closing the file.
     TString fPermanentName;
     Bool_t fMakePermanent;
+    Bool_t fUseTemporaryFile;
 
     /// Search for non-empty trees or histograms in the file
     Bool_t HasAnyFilled(void);

--- a/Analysis/src/QwRootFile.cc
+++ b/Analysis/src/QwRootFile.cc
@@ -77,16 +77,21 @@ QwRootFile::QwRootFile(const TString& run_label)
 
     fPermanentName = rootfilename
       + Form("/%s%s.root", fRootFileStem.Data(), run_label.Data());
-    rootfilename += Form("/%s%s.%s.%d.root",
-			 fRootFileStem.Data(), run_label.Data(),
-			 hostname.Data(), pid);
+    if (fUseTemporaryFile){
+      rootfilename += Form("/%s%s.%s.%d.root",
+			   fRootFileStem.Data(), run_label.Data(),
+			   hostname.Data(), pid);
+    } else {
+      rootfilename = fPermanentName;
+    }
     fRootFile = new TFile(rootfilename.Data(), "RECREATE", "myfile1");
     if (! fRootFile) {
       QwError << "ROOT file " << rootfilename
               << " could not be opened!" << QwLog::endl;
       return;
     } else {
-      QwMessage << "Opened temporary rootfile " << rootfilename << QwLog::endl;
+      QwMessage << "Opened "<< (fUseTemporaryFile?"temporary ":"")
+		<<"rootfile " << rootfilename << QwLog::endl;
     }
 
     TString run_condition_name = Form("%s_condition", run_label.Data());
@@ -136,20 +141,22 @@ QwRootFile::~QwRootFile()
 
     int err;
     const char* action;
-    if (fMakePermanent) {
-      action = " rename ";
-      err = rename( rootfilename.Data(), fPermanentName.Data() );
-    } else {
-      action = " remove ";
-      err = remove( rootfilename.Data() );
-    }
-    // It'd be proper to "extern int errno" and strerror() here,
-    // but that doesn't seem very C++-ish.
-    if (err) {
-      QwWarning << "Couldn't" << action << rootfilename << QwLog::endl;
-    } else {
-      QwMessage << "Was able to" << action << rootfilename << QwLog::endl;
-      QwMessage << "Root file is " << fPermanentName << QwLog::endl;
+    if (fUseTemporaryFile){
+      if (fMakePermanent) {
+	action = " rename ";
+	err = rename( rootfilename.Data(), fPermanentName.Data() );
+      } else {
+	action = " remove ";
+	err = remove( rootfilename.Data() );
+      }
+      // It'd be proper to "extern int errno" and strerror() here,
+      // but that doesn't seem very C++-ish.
+      if (err) {
+	QwWarning << "Couldn't" << action << rootfilename << QwLog::endl;
+      } else {
+	QwMessage << "Was able to" << action << rootfilename << QwLog::endl;
+	QwMessage << "Root file is " << fPermanentName << QwLog::endl;
+      }
     }
   }
 
@@ -178,6 +185,9 @@ void QwRootFile::DefineOptions(QwOptions &options)
   options.AddOptions()
     ("enable-mapfile", po::value<bool>()->default_bool_value(false),
      "enable output to memory-mapped file\n(likely requires circular-buffer too)");
+  options.AddOptions()
+    ("write-temporary-rootfiles", po::value<bool>()->default_bool_value(true),
+     "When writing ROOT files, use the PID to create a temporary filename");
 
   // Define the histogram and tree options
   options.AddOptions("ROOT output options")
@@ -248,6 +258,7 @@ void QwRootFile::ProcessOptions(QwOptions &options)
 
   // Option 'mapfile' to enable memory-mapped ROOT file
   fEnableMapFile = options.GetValue<bool>("enable-mapfile");
+  fUseTemporaryFile = options.GetValue<bool>("write-temporary-rootfiles");
 
   // Options 'disable-trees' and 'disable-histos' for disabling
   // tree and histogram output


### PR DESCRIPTION
If this flag (write-temporary-rootfiles) is false, then we will not create the "unique"
rootfile name by using the machine and process ID in the file name.  This is most useful
to make sure that panguin can find the correct "online" rootfile, by making sure there
is only one file.