### PR TITLE
Specify linregblue correlator output ROOT file name

### DIFF
--- a/Parity/include/QwCorrelator.h
+++ b/Parity/include/QwCorrelator.h
@@ -54,6 +54,8 @@ class QwCorrelator : public VQwDataHandler, public MQwDataHandlerCloneable<QwCor
   std::vector< const VQwHardwareChannel* > fIndependentVar;
   std::vector< Double_t > fIndependentValues;
 
+  std::string fAlphaOutputFileBase;
+  std::string fAlphaOutputFileSuff;
   std::string fAlphaOutputPath;
   std::string fAliasOutputPath;		
 

--- a/Parity/prminput/prex_datahandlers.map
+++ b/Parity/prminput/prex_datahandlers.map
@@ -12,6 +12,8 @@
   name       = MyCorrelator
   priority   = 50
   map        = prex_corrolator.conf
+  slope-file-base = blueR
+  slope-file-suff = new.slope.root
   slope-path = . 
   alias-path = .
   disable-histos = true

--- a/Parity/src/QwCorrelator.cc
+++ b/Parity/src/QwCorrelator.cc
@@ -35,6 +35,8 @@ RegisterHandlerFactory(QwCorrelator);
 //******************************************************************************************************************************************************
 
 QwCorrelator::QwCorrelator(const TString& name):VQwDataHandler(name),
+                                               fAlphaOutputFileBase("blueR"),
+                                               fAlphaOutputFileSuff("new.slope.root"),
 					       fAlphaOutputPath("."),
 					       fAliasOutputPath("."),
 					       fDisableHistos(true),
@@ -48,6 +50,8 @@ QwCorrelator::QwCorrelator(const TString& name):VQwDataHandler(name),
 void QwCorrelator::ParseConfigFile(QwParameterFile& file)
 {
   VQwDataHandler::ParseConfigFile(file);
+  file.PopValue("slope-file-base", fAlphaOutputFileBase);
+  file.PopValue("slope-file-suff", fAlphaOutputFileSuff);
   file.PopValue("slope-path", fAlphaOutputPath);
   file.PopValue("alias-path", fAliasOutputPath);
   file.PopValue("disable-histos", fDisableHistos);
@@ -98,7 +102,7 @@ void QwCorrelator::CalcCorrelations()
   corA.finish();
 	
   std::string TmpRunLabel = run_label.Data();
-  std::string fSlopeFileName = "blueR" + TmpRunLabel + "new.slope.root";
+  std::string fSlopeFileName = fAlphaOutputFileBase + TmpRunLabel + fAlphaOutputFileSuff;
   std::string fSlopeFilePath = fAlphaOutputPath + "/";
   std::string tmp = fSlopeFilePath + fSlopeFileName;
 


### PR DESCRIPTION
New options slope-file-base, slope-file-suff to set the name of the
blueR####.new.slope.root file to something else to avoid clobbering.

Default settings (if not specified) are (historically):
```
  slope-file-base = blueR
  slope-file-suff = new.slope.root
```