### PR TITLE
Remove QwVQWK_Channel::fRunningSum, not used and confusing

### DIFF
--- a/Analysis/include/QwVQWK_Channel.h
+++ b/Analysis/include/QwVQWK_Channel.h
@@ -275,9 +275,6 @@ private:
   static const Int_t  kWordsPerChannel; //no.of words per channel in the CODA buffer
   static const Int_t  kMaxChannels;     //no.of channels per module
 
-  /// Pointer to the running sum for this channel
-  QwVQWK_Channel* fRunningSum;
-
   /*! \name ADC Calibration                    */
   // @{
   static const Double_t kVQWK_VoltsPerBit;

--- a/Analysis/src/QwVQWK_Channel.cc
+++ b/Analysis/src/QwVQWK_Channel.cc
@@ -205,8 +205,6 @@ void QwVQWK_Channel::InitializeChannel(TString name, TString datatosave)
   fErrorCount_ZeroHW     = 0;
   fErrorCount_HWSat      = 0;
 
-  fRunningSum            = 0;
-
   fADC_Same_NumEvt       = 0;
   fSequenceNo_Prev       = 0;
   fSequenceNo_Counter    = 0;
@@ -1335,12 +1333,6 @@ void QwVQWK_Channel::DivideBy(const QwVQWK_Channel &denom)
  */
 void QwVQWK_Channel::AccumulateRunningSum(const QwVQWK_Channel& value, Int_t count)
 {
-  // Store pointer to running sum
-  if (value.fRunningSum == 0) {
-    QwVQWK_Channel* vqwk = const_cast<QwVQWK_Channel*>(&value);
-    vqwk->fRunningSum = this;
-  }
-
   // Moment calculations
   Bool_t berror=kTRUE;//only needed for deaccumulation (stability check purposes)
 


### PR DESCRIPTION
Whereas a running sum may at some point have been part of the channel
we are now using a strategy of keeping running sums entirely outside
the channels so we can have multiple of them at different time scales.

No effects. No hits on `grep -r fRunningSum` (except for things called ...diffRunningSum).