### PR TITLE
Removed fRunningSum from data handlers

### DIFF
--- a/Parity/include/QwDataHandlerArray.h
+++ b/Parity/include/QwDataHandlerArray.h
@@ -113,9 +113,6 @@ class QwDataHandlerArray:  public std::vector<boost::shared_ptr<VQwDataHandler> 
     */
 
     /// \brief Update the running sums for devices accumulated for the global error non-zero events/patterns
-    void AccumulateRunningSum();
-
-    /// \brief Update the running sums for devices accumulated for the global error non-zero events/patterns
     void AccumulateRunningSum(const QwDataHandlerArray& value);
     /// \brief Update the running sums for devices check only the error flags at the channel level. Only used for stability checks
     void AccumulateAllRunningSum(const QwDataHandlerArray& value);

--- a/Parity/include/VQwDataHandler.h
+++ b/Parity/include/VQwDataHandler.h
@@ -61,10 +61,8 @@ class VQwDataHandler:  virtual public VQwDataHandlerCloneable {
 
     void ClearEventData();
 
-    virtual void AccumulateRunningSum();
     void AccumulateRunningSum(VQwDataHandler &value);
     void CalculateRunningAverage();
-    void PrintRunningAverage();
     void PrintValue() const;
     void FillDB(QwParityDB *db, TString datatype){};
 
@@ -132,7 +130,6 @@ class VQwDataHandler:  virtual public VQwDataHandlerCloneable {
 
  protected:
    Bool_t fKeepRunningSum;
-   VQwDataHandler *fRunningSum;
 };
 
 #endif // VQWDATAHANDLER_H_

--- a/Parity/src/QwDataHandlerArray.cc
+++ b/Parity/src/QwDataHandlerArray.cc
@@ -472,27 +472,8 @@ void QwDataHandlerArray::CalculateRunningAverage()
       VQwDataHandler* handler_parity = dynamic_cast<VQwDataHandler*>(handler->get());
       handler_parity->CalculateRunningAverage();
     }
-    if (fPrintRunningSum){
-      for (iterator handler = begin(); handler != end(); ++handler) {
-	VQwDataHandler* handler_parity = dynamic_cast<VQwDataHandler*>(handler->get());
-	handler_parity->PrintRunningAverage();
-      }
-    }
   }
 }
-
-void QwDataHandlerArray::AccumulateRunningSum()
-{
-  if (!empty()) {
-    if (fDataSource->GetEventcutErrorFlag() == 0){
-      for (iterator handler = begin(); handler != end(); ++handler) {
-	VQwDataHandler* handler_parity = dynamic_cast<VQwDataHandler*>(handler->get());
-	handler_parity->AccumulateRunningSum();
-      }
-    }
-  }
-}
-
 
 void QwDataHandlerArray::AccumulateRunningSum(const QwDataHandlerArray& value)
 {
@@ -660,7 +641,6 @@ void QwDataHandlerArray::ProcessDataHandlerEntry()
     for(iterator handler = begin(); handler != end(); ++handler){
       (*handler)->ProcessData();
     }
-    this->AccumulateRunningSum();
   }
 }
 

--- a/Parity/src/VQwDataHandler.cc
+++ b/Parity/src/VQwDataHandler.cc
@@ -250,19 +250,6 @@ void VQwDataHandler::FillTreeVector(std::vector<Double_t>& values) const
   }
 }
 
-    
-void VQwDataHandler::AccumulateRunningSum()
-{
-  if (fKeepRunningSum){
-    //  Create the running sum object if it doesn't exist.
-    if (fRunningSum == NULL){
-      fRunningSum = this->Clone();
-      fRunningSum->fKeepRunningSum = kFALSE;
-      fRunningSum->ClearEventData();
-    }
-    fRunningSum->AccumulateRunningSum(*this);
-  }
-}
 
 void VQwDataHandler::AccumulateRunningSum(VQwDataHandler &value)
 {
@@ -274,22 +261,10 @@ void VQwDataHandler::AccumulateRunningSum(VQwDataHandler &value)
 
 void VQwDataHandler::CalculateRunningAverage()
 {
-  if (fKeepRunningSum && (fRunningSum != NULL)){
-    for(size_t i = 0; i < fRunningSum->fOutputVar.size(); i++) {
-      // calling CalculateRunningAverage in scope of VQwHardwareChannel
-      fRunningSum->fOutputVar[i]->CalculateRunningAverage();
-    }
-  }
-  return;
-}
-
-void VQwDataHandler::PrintRunningAverage()
-{
-  if (fKeepRunningSum && (fRunningSum != NULL)){
-    fRunningSum->PrintValue();
+  for(size_t i = 0; i < fOutputVar.size(); i++) {
+    this->fOutputVar[i]->CalculateRunningAverage();
   }
 }
-
 
 void VQwDataHandler::PrintValue() const
 {
@@ -309,9 +284,6 @@ void VQwDataHandler::ClearEventData()
 
 void VQwDataHandler::WritePromptSummary(QwPromptSummary *ps, TString type)
 {
-  //  Only do something, if we have the running sum variables
-  if (!fKeepRunningSum || (fRunningSum == NULL)) return;
-
      Bool_t local_print_flag = false;
      Bool_t local_add_element= type.Contains("asy");
   
@@ -334,7 +306,7 @@ void VQwDataHandler::WritePromptSummary(QwPromptSummary *ps, TString type)
   for (size_t i = 0; i < fOutputVar.size();  i++) 
     {
       element_name        = fOutputVar[i]->GetElementName(); 
-      tmp_channel=fRunningSum->fOutputVar[i];
+      tmp_channel         = fOutputVar[i];
       element_value       = 0.0;
       element_value_err   = 0.0;
       element_value_width = 0.0;


### PR DESCRIPTION
This was a change that @paulmking and I started implementing last Friday but I can't exactly remember why it was so important that it should have its own branch...

I guess the point was that we are now using things like
```
datahandlerarray_run.AccumulateRunningSum(datahandlerarray);
```
instead of `datahandlerarray_run.AccumulateRunningSum();`

This is part of the burst regression scheme mechanics.