### PR TITLE
Optional tree and branch prefix in data handler ConstructTreeBranches.

### DIFF
--- a/Parity/include/QwDataHandlerArray.h
+++ b/Parity/include/QwDataHandlerArray.h
@@ -78,7 +78,10 @@ class QwDataHandlerArray:  public std::vector<boost::shared_ptr<VQwDataHandler> 
 
     std::vector<VQwDataHandler*> GetDataHandlerByType(const std::string& type);
 
-    void ConstructTreeBranches(QwRootFile *treerootfile);
+    void ConstructTreeBranches(
+        QwRootFile *treerootfile,
+        const std::string& treeprefix = "",
+        const std::string& branchprefix = "");
 
     /// \brief Construct a branch and vector for this handler with a prefix
     void ConstructBranchAndVector(TTree *tree, TString& prefix, std::vector <Double_t> &values);

--- a/Parity/include/VQwDataHandler.h
+++ b/Parity/include/VQwDataHandler.h
@@ -70,7 +70,10 @@ class VQwDataHandler:  virtual public VQwDataHandlerCloneable {
 
     void WritePromptSummary(QwPromptSummary *ps, TString type);
 
-    void ConstructTreeBranches(QwRootFile *treerootfile);
+    void ConstructTreeBranches(
+        QwRootFile *treerootfile,
+        const std::string& treeprefix = "",
+        const std::string& branchprefix = "");
     void FillTreeBranches(QwRootFile *treerootfile);
 
     // Fill the vector for this subsystem

--- a/Parity/src/QwDataHandlerArray.cc
+++ b/Parity/src/QwDataHandlerArray.cc
@@ -320,11 +320,14 @@ void  QwDataHandlerArray::ProcessEvent()
   }
 }
 
-void  QwDataHandlerArray::ConstructTreeBranches(QwRootFile *treerootfile)
+void  QwDataHandlerArray::ConstructTreeBranches(
+    QwRootFile *treerootfile,
+    const std::string& treeprefix,
+    const std::string& branchprefix)
 {
   if (!empty()){
     for (iterator handler = begin(); handler != end(); ++handler) {
-      handler->get()->ConstructTreeBranches(treerootfile);
+      handler->get()->ConstructTreeBranches(treerootfile, treeprefix, branchprefix);
     }
   }
 }

--- a/Parity/src/VQwDataHandler.cc
+++ b/Parity/src/VQwDataHandler.cc
@@ -211,10 +211,13 @@ pair<VQwDataHandler::EQwHandleType,string> VQwDataHandler::ParseHandledVariable(
   
 }
 
-void VQwDataHandler::ConstructTreeBranches(QwRootFile *treerootfile)
+void VQwDataHandler::ConstructTreeBranches(
+    QwRootFile *treerootfile,
+    const std::string& treeprefix,
+    const std::string& branchprefix)
 {
   if (fTreeName.size()>0){
-    treerootfile->ConstructTreeBranches(fTreeName, fTreeComment, *this, fPrefix);
+    treerootfile->ConstructTreeBranches(treeprefix + fTreeName, fTreeComment, *this, branchprefix + fPrefix);
   }
 }
 


### PR DESCRIPTION
Since we end up with several lines like:
```
    datahandlerarray1.ConstructTreeBranches(rootfile);
    datahandlerarray2.ConstructTreeBranches(rootfile);
```
where `datahandlerarray2` is either a copy of or constructed the same was as `datahandlerarray1`, we need a way to distinguishing where their output goes. We can either change the tree name or change the branch names. Examples:
```
    datahandlerarray1.ConstructTreeBranches(rootfile,"dh1_");
    datahandlerarray2.ConstructTreeBranches(rootfile,"dh2_");
```
will cause trees `dh1_<defaultname>` and `dh2_<defaultname>`.
```
    datahandlerarray1.ConstructTreeBranches(rootfile,"","dh1_");
    datahandlerarray2.ConstructTreeBranches(rootfile,"","dh2_");
```
will cause one tree `<defaultname>` with branches `dh1_<channel>` and `dh2_<channel>`.

Either way should make it easy to distinguish what's going on.

- Pros for using tree disambiguation: we already have many branch, no need to clutter even more.
- Pros for using branch disambiguation: would allow plotting `dh1_<channel>:dh2_<channel>` more easily.