### PR TITLE
Feature: Allow event ring to unwind 🏖

### DIFF
--- a/Analysis/src/QwVQWK_Channel.cc
+++ b/Analysis/src/QwVQWK_Channel.cc
@@ -1393,11 +1393,41 @@ void QwVQWK_Channel::AccumulateRunningSum(const QwVQWK_Channel& value, Int_t cou
 	fBlock[i] -= (M12 - M11) / n;
 	fBlockM2[i] -= (M12 - M11) * (M12 - fBlock[i]); // note: using updated mean
       }
-    }else if (n==0){
-      //QwMessage<<"Deaccumulate at zero "<<QwLog::endl;
-      /* 
-      //Need any fail safe check for Deaccumulation????
-      */
+    } else if (n == 1) {
+      fHardwareBlockSum -= (M12 - M11) / n;
+      fHardwareBlockSumM2 -= (M12 - M11)
+        * (M12 - fHardwareBlockSum); // note: using updated mean
+      if (fabs(fHardwareBlockSumM2) < 10.*std::numeric_limits<double>::epsilon())
+        fHardwareBlockSumM2 = 0; // rounding
+      // and for individual blocks
+      for (Int_t i = 0; i < 4; i++) {
+        M11 = fBlock[i];
+        M12 = value.fBlock[i];
+        M22 = value.fBlockM2[i];
+        fBlock[i] -= (M12 - M11) / n;
+        fBlockM2[i] -= (M12 - M11) * (M12 - fBlock[i]); // note: using updated mean
+        if (fabs(fBlockM2[i]) < 10.*std::numeric_limits<double>::epsilon())
+          fBlockM2[i] = 0; // rounding
+      }
+    } else if (n == 0) {
+      fHardwareBlockSum -= M12;
+      fHardwareBlockSumM2 -= M22;
+      if (fabs(fHardwareBlockSum) < 10.*std::numeric_limits<double>::epsilon())
+        fHardwareBlockSum = 0; // rounding
+      if (fabs(fHardwareBlockSumM2) < 10.*std::numeric_limits<double>::epsilon())
+        fHardwareBlockSumM2 = 0; // rounding
+      // and for individual blocks
+      for (Int_t i = 0; i < 4; i++) {
+        M11 = fBlock[i];
+        M12 = value.fBlock[i];
+        M22 = value.fBlockM2[i];
+        fBlock[i] -= M12;
+        fBlockM2[i] -= M22;
+        if (fabs(fBlock[i]) < 10.*std::numeric_limits<double>::epsilon())
+          fBlock[i] = 0; // rounding
+        if (fabs(fBlockM2[i]) < 10.*std::numeric_limits<double>::epsilon())
+          fBlockM2[i] = 0; // rounding
+      }
     }
 
   } else if (n2 == 1) {

--- a/Analysis/src/QwVQWK_Channel.cc
+++ b/Analysis/src/QwVQWK_Channel.cc
@@ -1381,8 +1381,7 @@ void QwVQWK_Channel::AccumulateRunningSum(const QwVQWK_Channel& value, Int_t cou
   } else if (n2 == -1) {
     // simple version for removal of single event from the sum
     fGoodEventCount--;
-    //QwMessage<<"Deaccumulate before "<<QwLog::endl;
-    if (n>0){
+    if (n > 1) {
       fHardwareBlockSum -= (M12 - M11) / n;
       fHardwareBlockSumM2 -= (M12 - M11)
 	* (M12 - fHardwareBlockSum); // note: using updated mean
@@ -1433,10 +1432,6 @@ void QwVQWK_Channel::AccumulateRunningSum(const QwVQWK_Channel& value, Int_t cou
   // Nanny
   if (fHardwareBlockSum != fHardwareBlockSum)
     QwWarning << "Angry Nanny: NaN detected in " << GetElementName() << QwLog::endl;
-
-
-   
-
 }
 
 

--- a/Analysis/src/QwVQWK_Channel.cc
+++ b/Analysis/src/QwVQWK_Channel.cc
@@ -1428,6 +1428,8 @@ void QwVQWK_Channel::AccumulateRunningSum(const QwVQWK_Channel& value, Int_t cou
         if (fabs(fBlockM2[i]) < 10.*std::numeric_limits<double>::epsilon())
           fBlockM2[i] = 0; // rounding
       }
+    } else {
+      QwWarning << "Running sum has deaccumulated to negative good events." << QwLog::endl;
     }
 
   } else if (n2 == 1) {

--- a/Parity/include/QwEventRing.h
+++ b/Parity/include/QwEventRing.h
@@ -26,7 +26,6 @@ class QwEventRing {
 
  public:
   QwEventRing(QwOptions &options, QwSubsystemArrayParity &event);
-  QwEventRing(QwSubsystemArrayParity &event, Int_t ring_size); //this will create a fixed size event ring
   virtual ~QwEventRing() { };
 
   /// \brief Define options

--- a/Parity/include/QwEventRing.h
+++ b/Parity/include/QwEventRing.h
@@ -47,10 +47,14 @@ class QwEventRing {
   /// \brief Return the read status of the ring
   Bool_t IsReady();
 
+  /// \brief Return the number of events in the ring
+  Int_t GetNumberOfEvents() const { return fNumberOfEvents; }
+
  private:
 
   Int_t fRING_SIZE;//this is the length of the ring
 
+  Int_t fNumberOfEvents;
 
   Int_t fNextToBeFilled;//counts events in the ring
   Int_t fNextToBeRead;//keep track off when to read next from the ring.

--- a/Parity/include/QwEventRing.h
+++ b/Parity/include/QwEventRing.h
@@ -68,7 +68,8 @@ class QwEventRing {
   Int_t fNextToBeFilled;//counts events in the ring
   Int_t fNextToBeRead;//keep track off when to read next from the ring.
 
-  
+  Bool_t fPrintAfterUnwind; // print rolling average after unwinding
+
   Bool_t bEVENT_READY; //If kTRUE, the good events are added to the event ring. After a beam trip this is set to kFALSE
   //after discarding LEAVE_COUNT no.of good event this is set to kTRUE
 

--- a/Parity/include/QwEventRing.h
+++ b/Parity/include/QwEventRing.h
@@ -38,6 +38,12 @@ class QwEventRing {
   /// \brief Return the last subsystem in the ring
   QwSubsystemArrayParity& pop();
 
+  /// \brief Print value of rolling average
+  void PrintRollingAverage() {
+    fRollingAvg.CalculateRunningAverage();
+    fRollingAvg.PrintValue();
+  }
+
   /// \brief Return the read status of the ring
   Bool_t IsReady();
 

--- a/Parity/include/QwEventRing.h
+++ b/Parity/include/QwEventRing.h
@@ -50,6 +50,15 @@ class QwEventRing {
   /// \brief Return the number of events in the ring
   Int_t GetNumberOfEvents() const { return fNumberOfEvents; }
 
+  /// \brief Unwind the ring until empty
+  void Unwind() {
+    while (GetNumberOfEvents() > 0) pop();
+    if (fPrintAfterUnwind) {
+      QwMessage << "Residual rolling average (should be zero)" << QwLog::endl;
+      PrintRollingAverage();
+    }
+  }
+
  private:
 
   Int_t fRING_SIZE;//this is the length of the ring

--- a/Parity/main/QwParity.cc
+++ b/Parity/main/QwParity.cc
@@ -356,11 +356,7 @@ Int_t main(Int_t argc, Char_t* argv[])
     
     // Unwind event ring
     QwMessage << "Unwinding event ring" << QwLog::endl;
-    while (eventring.GetNumberOfEvents() > 0) {
-      eventring.pop();
-    }
-    //QwMessage << "Residual rolling average (should be zero)" << QwLog::endl;
-    //eventring.PrintRollingAverage();
+    eventring.Unwind();
 
     //  Perform actions at the end of the event loop on the
     //  detectors object, which ought to have handles for the

--- a/Parity/main/QwParity.cc
+++ b/Parity/main/QwParity.cc
@@ -354,6 +354,14 @@ Int_t main(Int_t argc, Char_t* argv[])
 
     } // end of loop over events
     
+    // Unwind event ring
+    QwMessage << "Unwinding event ring" << QwLog::endl;
+    while (eventring.GetNumberOfEvents() > 0) {
+      eventring.pop();
+    }
+    //QwMessage << "Residual rolling average (should be zero)" << QwLog::endl;
+    //eventring.PrintRollingAverage();
+
     //  Perform actions at the end of the event loop on the
     //  detectors object, which ought to have handles for the
     //  MPS based histograms.

--- a/Parity/src/QwEventRing.cc
+++ b/Parity/src/QwEventRing.cc
@@ -30,6 +30,9 @@ void QwEventRing::DefineOptions(QwOptions &options)
   options.AddOptions()("ring.stability_cut",
       po::value<double>()->default_value(1),
       "QwEventRing: Stability ON/OFF");
+  options.AddOptions()("ring.print-after-unwind",
+      po::value<bool>()->default_bool_value(false),
+      "QwEventRing: print rolling avg after unwind");
 }
 
 void QwEventRing::ProcessOptions(QwOptions &options)
@@ -46,7 +49,8 @@ void QwEventRing::ProcessOptions(QwOptions &options)
     bStability=kTRUE;
   else
     bStability=kFALSE;
- 
+
+  fPrintAfterUnwind = gQwOptions.GetValue<bool>("ring.print-after-unwind");
 }
 void QwEventRing::push(QwSubsystemArrayParity &event)
 {

--- a/Parity/src/QwEventRing.cc
+++ b/Parity/src/QwEventRing.cc
@@ -8,10 +8,11 @@ QwEventRing::QwEventRing(QwOptions &options, QwSubsystemArrayParity &event)
 
   fEvent_Ring.resize(fRING_SIZE,event);
 
-  bRING_READY=kFALSE;
-  bEVENT_READY=kTRUE;
-  fNextToBeFilled=0;
-  fNextToBeRead=0;
+  bRING_READY = kFALSE;
+  bEVENT_READY = kTRUE;
+
+  fNextToBeFilled = 0;
+  fNextToBeRead = 0;
 
   //open the log file
   if (bDEBUG_Write)
@@ -22,7 +23,6 @@ QwEventRing::QwEventRing(QwOptions &options, QwSubsystemArrayParity &event)
 void QwEventRing::DefineOptions(QwOptions &options)
 {
   // Define the execution options
-  options.AddDefaultOptions();
   options.AddOptions()("ring.size",
       po::value<int>()->default_value(4800),
       "QwEventRing: ring/buffer size");
@@ -103,10 +103,7 @@ void QwEventRing::push(QwSubsystemArrayParity &event)
 	}
     }
     //ring processing is done at a separate location
-  }else{
   }
-  
-  
 }
 
 

--- a/Parity/src/QwEventRing.cc
+++ b/Parity/src/QwEventRing.cc
@@ -1,24 +1,6 @@
 #include "QwEventRing.h"
 
 
-
-QwEventRing::QwEventRing(QwSubsystemArrayParity &event, Int_t ring_size)
-: fRollingAvg(event)
-{
-  fRING_SIZE=ring_size;
-  fEvent_Ring.resize(fRING_SIZE,event);
-
-  bRING_READY=kFALSE;
-  bEVENT_READY=kTRUE;
-  fNextToBeFilled=0;
-  fNextToBeRead=0;
-  
-  //open the log file
-  if (bDEBUG_Write)
-    out_file = fopen("Ring_log.txt", "wt");
-}
-
-
 QwEventRing::QwEventRing(QwOptions &options, QwSubsystemArrayParity &event)
 : fRollingAvg(event)
 {

--- a/Parity/src/QwEventRing.cc
+++ b/Parity/src/QwEventRing.cc
@@ -11,6 +11,7 @@ QwEventRing::QwEventRing(QwOptions &options, QwSubsystemArrayParity &event)
   bRING_READY = kFALSE;
   bEVENT_READY = kTRUE;
 
+  fNumberOfEvents = 0;
   fNextToBeFilled = 0;
   fNextToBeRead = 0;
 
@@ -65,8 +66,9 @@ void QwEventRing::push(QwSubsystemArrayParity &event)
     if (bDEBUG) QwMessage<<" Filled at "<<thisevent;//<<"Ring count "<<fRing_Count<<QwLog::endl; 
     if (bDEBUG_Write) fprintf(out_file," Filled at %d ",thisevent);
 
-
-    fNextToBeFilled=(thisevent+1)%fRING_SIZE;
+    // Increment fill index
+    fNumberOfEvents ++;
+    fNextToBeFilled = (thisevent + 1) % fRING_SIZE;
     
     if(fNextToBeFilled == 0){
       //then we have RING_SIZE events to process
@@ -119,7 +121,12 @@ QwSubsystemArrayParity& QwEventRing::pop(){
   if (bStability){
      fRollingAvg.DeaccumulateRunningSum(fEvent_Ring[tempIndex]);
   }
-  fNextToBeRead=(fNextToBeRead+1)%fRING_SIZE;  
+
+  // Increment read index
+  fNumberOfEvents --;
+  fNextToBeRead = (fNextToBeRead + 1) % fRING_SIZE;
+
+  // Return the event
   return fEvent_Ring[tempIndex];  
 }
 


### PR DESCRIPTION
At the end of a run we have stuff in the event ring. Although only 200 events, so unlikely to be useful for statistical precision, we don't do anything with these events. This adds the functionality to unwind the event ring (and still not do anything with these events) to test whether problems occur. If the event ring rolling average is non-zero then something fishy happened.

Functionality consists of:
- keeping track of how many events are in the event ring
- printing the rolling average in the event ring
- unwinding after the main event loop
- small fixes in deaccumulation of VQWK channels