### PR TITLE
Bugfix for off by one error on the "|stat" parsing.

### DIFF
--- a/Analysis/src/QwADC18_Channel.cc
+++ b/Analysis/src/QwADC18_Channel.cc
@@ -572,7 +572,7 @@ void  QwADC18_Channel::ConstructBranchAndVector(TTree *tree, TString &prefix, st
     //  Decide what to store based on prefix
     SetDataToSaveByPrefix(prefix);
 
-    TString basename = prefix(0, (prefix.First("|") > 0)? prefix.First("|"): prefix.Length()) + GetElementName();
+    TString basename = prefix(0, (prefix.First("|") >= 0)? prefix.First("|"): prefix.Length()) + GetElementName();
     fTreeArrayIndex  = values.size();
 
     TString list;

--- a/Analysis/src/QwScaler_Channel.cc
+++ b/Analysis/src/QwScaler_Channel.cc
@@ -262,7 +262,7 @@ void QwScaler_Channel<data_mask,data_shift>::ConstructBranchAndVector(TTree *tre
     //  Decide what to store based on prefix
     SetDataToSaveByPrefix(prefix);
 
-    TString basename = prefix(0, (prefix.First("|") > 0)? prefix.First("|"): prefix.Length()) + GetElementName();
+    TString basename = prefix(0, (prefix.First("|") >= 0)? prefix.First("|"): prefix.Length()) + GetElementName();
     fTreeArrayIndex  = values.size();
 
     TString list;

--- a/Analysis/src/QwVQWK_Channel.cc
+++ b/Analysis/src/QwVQWK_Channel.cc
@@ -676,7 +676,7 @@ void  QwVQWK_Channel::ConstructBranchAndVector(TTree *tree, TString &prefix, std
   //  Decide what to store based on prefix
   SetDataToSaveByPrefix(prefix);
 
-  TString basename = prefix(0, (prefix.First("|") > 0)? prefix.First("|"): prefix.Length()) + GetElementName();
+  TString basename = prefix(0, (prefix.First("|") >= 0)? prefix.First("|"): prefix.Length()) + GetElementName();
   fTreeArrayIndex  = values.size();
 
   TString list = "";


### PR DESCRIPTION
This caused the evts tree in feature-burst-outside-helicitypattern
to not store the correct branch names when saved with "|stat" but
not "yield|stat".

Proposed as PR on develop since it's a bug that could potentially
show up in develop...