### PR TITLE
Bugfix: Improve deaccumulation for VQWK, implement for scalers

### DIFF
--- a/Analysis/src/QwScaler_Channel.cc
+++ b/Analysis/src/QwScaler_Channel.cc
@@ -209,10 +209,14 @@ void VQwScaler_Channel::ProcessEvent()
 
 void VQwScaler_Channel::PrintValue() const
 {
-  //  printf("Name %s %23.4f +/- %15.4f", GetElementName().Data(), fValue, fValueError);
-  QwMessage << std::setw(5) << std::left << GetElementName() << " , "
-	    << std::setprecision(4)
-	    << std::setw(5) << std::right << GetValue() << "  +/-  " << GetValueError() << " sigma "<<GetValueWidth()
+  QwMessage << std::setprecision(4)
+            << std::setw(18) << std::left << GetSubsystemName()  << " "
+            << std::setw(18) << std::left << GetModuleType()     << " "
+            << std::setw(18) << std::left << GetElementName()    << " "
+	    << std::setw(12) << std::left << GetValue()          << "  +/-  "
+	    << std::setw(12) << std::left << GetValueError()     << "  sig  "
+            << std::setw(12) << std::left << GetValueWidth()     << " "
+            << std::setw(12) << std::left << GetGoodEventCount() << " "
 	    << QwLog::endl;
 }
 

--- a/Analysis/src/QwVQWK_Channel.cc
+++ b/Analysis/src/QwVQWK_Channel.cc
@@ -1338,50 +1338,51 @@ void QwVQWK_Channel::DivideBy(const QwVQWK_Channel &denom)
  */
 void QwVQWK_Channel::AccumulateRunningSum(const QwVQWK_Channel& value, Int_t count)
 {
-  // Moment calculations
-  Bool_t berror=kTRUE;//only needed for deaccumulation (stability check purposes)
-
   /*
     note:
-    The AccumulateRunningSum is called on a dedicated subsystem array object and for the standard running avg computations
-    we only need value.fErrorFlag==0 events to be included in the running avg. So the "berror" conditions is only used for the stability check purposes.
+    The AccumulateRunningSum is called on a dedicated subsystem array object and
+    for the standard running avg computations we only need value.fErrorFlag==0
+    events to be included in the running avg. So the "berror" conditions is only
+    used for the stability check purposes.
 
-    The need for this check below came due to fact that when routine DeaccumulateRunningSum is called the errorflag is updated with 
-    the kBeamStabilityError flag (+ configuration flags for global errors) and need to make sure we remove this flag and any configuration flags before 
+    The need for this check below came due to fact that when routine
+    DeaccumulateRunningSum is called the errorflag is updated with
+    the kBeamStabilityError flag (+ configuration flags for global errors) and
+    need to make sure we remove this flag and any configuration flags before
     checking the (fErrorFlag != 0) condition
     
     See how the stability check is implemented in the QwEventRing class
 
     Rakitha
   */
-
-  if (count==-1 && value.fErrorFlag>0){
-    berror=(((value.fErrorFlag) & 0xFFFFFFF) == 0); //The operation value.fErrorFlag & 0xFFFFFFF set the stability failed error bit to zero //-value.fErrorConfigFlag
-    if (GetElementName()=="qwk_enegy"){//qwk_target_EffectiveCharge
-      PrintValue();
-    }
-  }
-
-  
   
   Int_t n1 = fGoodEventCount;
   Int_t n2 = count;
+
   // If there are no good events, check the error flag
-  if (n2 == 0 && (value.fErrorFlag) == 0) {
+  if (n2 == 0 && (value.fErrorFlag == 0)) {
     n2 = 1;
-    //one event is removed from the sum (Deaccumulation)
-  }else if (n2 == -1 && berror) { //check only single event cut errors except stability fail flag since by the time the value is deaccumulated this could be flagged as stability failed error. 
-    n2 = -1;
-  }else
-    n2 = -100;//ignore it
+  }
+
+  // If a single event is removed from the sum, check all but stability fail flags
+  if (n2 == -1) {
+    if (value.fErrorFlag & 0xFFFFFFF == 0) {
+      n2 = -1;
+    } else {
+      n2 = 0;
+    }
+  }
+
+  // New total number of good events
   Int_t n = n1 + n2;
+
   // Set up variables
   Double_t M11 = fHardwareBlockSum;
   Double_t M12 = value.fHardwareBlockSum;
   Double_t M22 = value.fHardwareBlockSumM2;
+
   if (n2 == 0) {
     // no good events for addition
-
     return;
   } else if (n2 == -1) {
     // simple version for removal of single event from the sum
@@ -1436,7 +1437,6 @@ void QwVQWK_Channel::AccumulateRunningSum(const QwVQWK_Channel& value, Int_t cou
     } else {
       QwWarning << "Running sum has deaccumulated to negative good events." << QwLog::endl;
     }
-
   } else if (n2 == 1) {
     // simple version for addition of single event
     fGoodEventCount++;
@@ -1474,12 +1474,6 @@ void QwVQWK_Channel::AccumulateRunningSum(const QwVQWK_Channel& value, Int_t cou
 
 void QwVQWK_Channel::CalculateRunningAverage()
 {
-  /*
-  if (GetElementName()=="qwk_engy"){//qwk_target_EffectiveCharge
-      PrintValue();
-  }
-  */
-
   if (fGoodEventCount <= 0)
     {
       for (Int_t i = 0; i < fBlocksPerEvent; i++) {
@@ -1498,16 +1492,15 @@ void QwVQWK_Channel::CalculateRunningAverage()
       for (Int_t i = 0; i < fBlocksPerEvent; i++)
         fBlockError[i] = sqrt(fBlockM2[i]) / fGoodEventCount;
       fHardwareBlockSumError = sqrt(fHardwareBlockSumM2) / fGoodEventCount;
-      //Stability check 83951872 
-      if ((fStability>0) &&( (fErrorConfigFlag & kStabilityCut)==kStabilityCut)){//check to see the channel has stability cut activated in the event cut file
-        /*
-          //for Debugging
-          PrintValue();
-        */
-        if (GetValueWidth()>fStability){//if the width is greater than the stability required flag the event
-          fErrorFlag=kBeamStabilityError;
-        }else
-          fErrorFlag=0;
+
+      // Stability check 83951872
+      if ((fStability>0) &&( (fErrorConfigFlag & kStabilityCut) == kStabilityCut)) {
+        // check to see the channel has stability cut activated in the event cut file
+	if (GetValueWidth() > fStability){
+	  // if the width is greater than the stability required flag the event
+	  fErrorFlag = kBeamStabilityError;
+	} else
+	  fErrorFlag = 0;
       }
           
     }

--- a/Analysis/src/QwVQWK_Channel.cc
+++ b/Analysis/src/QwVQWK_Channel.cc
@@ -1366,7 +1366,7 @@ void QwVQWK_Channel::AccumulateRunningSum(const QwVQWK_Channel& value, Int_t cou
 
   // If a single event is removed from the sum, check all but stability fail flags
   if (n2 == -1) {
-    if (value.fErrorFlag & 0xFFFFFFF == 0) {
+    if ((value.fErrorFlag & 0xFFFFFFF) == 0) {
       n2 = -1;
     } else {
       n2 = 0;


### PR DESCRIPTION
Since no deaccumulation was present for scalers, they didn't get handled correctly in the event ring. This introduces proper deaccumulation for scaler channels.