### PR TITLE
Feature: Two test scripts that use root-diff on a reference run on hallaweb

### DIFF
--- a/Tests/go_check.sh
+++ b/Tests/go_check.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+function usage() {
+  echo "Usage: $0 [-h] [-r run]"
+}
+
+if [ $# -lt 2 ] ; then
+  usage
+fi
+
+while getopts “:h:r:” opt; do
+  case $opt in
+    h) usage && exit ;;
+    r) run=$OPTARG ;;
+    *) usage && exit ;;
+  esac
+done
+
+go get go-hep.org/x/hep/groot/cmd/root-diff
+
+source SetupFiles/SET_ME_UP.bash
+
+if [ ! -f ${QW_DATA}/parity_ALL_${run}.dat ] ; then
+  wget http://hallaweb.jlab.org/12GeV/Moller/downloads/japan/parity_ALL_${run}.dat
+  mv parity_ALL_${run}.dat ${QW_DATA}
+fi
+make -C build && build/qwparity -c prex.conf -r $run -e :2k
+
+if [ ! -f prexALL_${run}.root ] ; then
+  wget http://hallaweb.jlab.org/12GeV/Moller/downloads/japan/develop/prexALL_${run}.root
+fi
+root-diff -k evt,mul prexALL_${run}.root ${QW_ROOTFILES}/prexALL_${run}.root

--- a/Tests/go_check.sh
+++ b/Tests/go_check.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 
 function usage() {
-  echo "Usage: $0 [-h] [-r run]"
+  echo "Usage: $0 [-h] [-r run=1296] [-b branch=develop]"
 }
 
-if [ $# -lt 2 ] ; then
-  usage
-fi
-
-while getopts “:h:r:” opt; do
+run=1296
+branch=develop
+while getopts “:h:r:g:” opt; do
   case $opt in
     h) usage && exit ;;
     r) run=$OPTARG ;;
+    b) branch=$OPTARG ;;
     *) usage && exit ;;
   esac
 done
@@ -27,6 +26,6 @@ fi
 make -C build && build/qwparity -c prex.conf -r $run -e :2k
 
 if [ ! -f prexALL_${run}.root ] ; then
-  wget http://hallaweb.jlab.org/12GeV/Moller/downloads/japan/develop/prexALL_${run}.root
+  wget -c -N http://hallaweb.jlab.org/12GeV/Moller/downloads/japan/${branch}/prexALL_${run}.root
 fi
 root-diff -k evt,mul prexALL_${run}.root ${QW_ROOTFILES}/prexALL_${run}.root

--- a/Tests/go_update.sh
+++ b/Tests/go_update.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
 function usage() {
-  echo "Usage: $0 [-h] [-r run]"
+  echo "Usage: $0 [-h] [-r run=1296]"
 }
 
 if [ $# -lt 2 ] ; then
   usage
 fi
 
+run=1296
 while getopts “:h:r:” opt; do
   case $opt in
     h) usage && exit ;;

--- a/Tests/go_update.sh
+++ b/Tests/go_update.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+function usage() {
+  echo "Usage: $0 [-h] [-r run]"
+}
+
+if [ $# -lt 2 ] ; then
+  usage
+fi
+
+while getopts “:h:r:” opt; do
+  case $opt in
+    h) usage && exit ;;
+    r) run=$OPTARG ;;
+    *) usage && exit ;;
+  esac
+done
+
+source SetupFiles/SET_ME_UP.bash
+
+if [ ! -f ${QW_DATA}/parity_ALL_${run}.dat ] ; then
+  wget http://hallaweb.jlab.org/12GeV/Moller/downloads/japan/parity_ALL_${run}.dat
+  mv parity_ALL_${run}.dat ${QW_DATA}
+fi
+make -C build && build/qwparity -c prex.conf -r $run -e :2k
+
+hallaweb=/group/halla/www/hallaweb/html/12GeV/Moller/downloads/japan/
+branch=`git rev-parse --abbrev-ref HEAD`
+if [ -d ${hallaweb} ] ; then
+  mkdir -p ${hallaweb}/${branch}
+  cp ${QW_ROOTFILES}/prexALL_${run}.root ${hallaweb}/${branch}/
+fi


### PR DESCRIPTION
Example: `Tests/go_check.sh -r 1296` will run qwparity for 2k events and do a root-diff with the reference root file from develop on hallaweb. `Tests/go_update.sh -r 1296` will update the file on hallaweb (if write permission, if on farm). Go is needed for go_check, not for go_update. Currently only supports run 1296 but easy to add to.

Goal is to do this somewhat automatically on travis (which supports go) but still trying to figure out how do square this with the docker containers we use.