### PR TITLE
Bugfix: Properly initialize scandata1 scandata2 cleandata in ROOT tree (MINOR)

### DIFF
--- a/Analysis/src/QwSubsystemArray.cc
+++ b/Analysis/src/QwSubsystemArray.cc
@@ -24,7 +24,7 @@
  * Create a subsystem array based on the configuration option 'detectors'
  */
 QwSubsystemArray::QwSubsystemArray(QwOptions& options, CanContainFn myCanContain)
-: fEventTypeMask(0x0),fnCanContain(myCanContain)
+: fCleanParameter{0,0,0},fEventTypeMask(0x0),fnCanContain(myCanContain)
 {
   ProcessOptionsToplevel(options);
   QwParameterFile detectors(fSubsystemsMapFile.c_str());
@@ -49,6 +49,9 @@ QwSubsystemArray::QwSubsystemArray(const QwSubsystemArray& source)
   fSubsystemsDisabledByName(source.fSubsystemsDisabledByName),
   fSubsystemsDisabledByType(source.fSubsystemsDisabledByType)
 {
+  for (size_t i = 0; i < 3; i++)
+    fCleanParameter[i] = source.fCleanParameter[i];
+
   fPublishedValuesDataElement.clear();
   fPublishedValuesSubsystem.clear();
   fPublishedValuesDescription.clear();


### PR DESCRIPTION
Without this initialization some random number is written to the
ROOT tree in both JLab CE and on gcc8 / ROOT 6.16. This causes all
ROOT files to differ every time.

Copy constructor copies values of scandata etc from the source object.
Equally valid, I think, could be to set them to zero again, but unlikely
to make any real difference.