### PR TITLE
Bugfix: Added CODA event type to the assignment operator= of array (MINOR)

### DIFF
--- a/Parity/src/QwSubsystemArrayParity.cc
+++ b/Parity/src/QwSubsystemArrayParity.cc
@@ -93,6 +93,7 @@ QwSubsystemArrayParity& QwSubsystemArrayParity::operator= (const QwSubsystemArra
     if (this->size() == source.size()){
       this->fErrorFlag=source.fErrorFlag;
       this->fCodaEventNumber=source.fCodaEventNumber;
+      this->fCodaEventType=source.fCodaEventType;
       for(size_t i=0;i<source.size();i++){
 	if (source.at(i)==NULL || this->at(i)==NULL){
 	  //  Either the source or the destination subsystem


### PR DESCRIPTION
This ensures that the evt tree contains the correct CodaEventType value. Currently it doesn't get copied out of the event ring and is filled with initial value (or worse, when using -O3, an uninitialized value).

We might have implemented an operator= in QwSubsystemArray instead of only the QwSubsystemArrayParity. Right now we have a compiler defined operator= for QwSubsystemArray which is unpredictable, at best, and wrong at worst.