### PR TITLE
Hotfix online blinder

### DIFF
--- a/Parity/include/QwBlinder.h
+++ b/Parity/include/QwBlinder.h
@@ -97,6 +97,8 @@ class QwBlinder {
 
     /// \brief Update the status with new external information
     void ProcessOptions(QwOptions& options);
+    /// \brief Update the status using a random number
+    void Update();
     /// \brief Update the status with new external information
     void Update(QwParityDB* db);
     /// \brief Update the status with new external information
@@ -302,6 +304,9 @@ class QwBlinder {
 
     ///  Reads the seed from the database object
     Int_t ReadSeed(QwParityDB* db);
+
+    ///  Read the seed string generated utilizing a random number generator
+    Int_t ReadRandomSeed();
 
     void WriteChecksum(QwParityDB* db);     ///  Writes fSeedID and fBFChecksum to DB for this analysis ID
     void WriteTestValues(QwParityDB* db);   ///  Writes fTestNumber and fBlindTestValue to DB for this analysis ID

--- a/Parity/include/QwHelicityPattern.h
+++ b/Parity/include/QwHelicityPattern.h
@@ -99,7 +99,10 @@ class QwHelicityPattern {
     fBlinder.Update(db);
   };
 #endif
-
+  /// Update the blinder status using a random number generator
+  void UpdateBlinder(){
+    fBlinder.Update();
+  };
   /// Update the blinder status with new external information
   void UpdateBlinder(const QwSubsystemArrayParity& detectors) {
     fBlinder.Update(detectors);

--- a/Parity/main/QwParity.cc
+++ b/Parity/main/QwParity.cc
@@ -255,8 +255,10 @@ Int_t main(Int_t argc, Char_t* argv[])
         eventbuffer.FillSubsystemConfigurationData(detectors);
       }
 
-      //  Secondly, process EPICS events
-      if (eventbuffer.IsEPICSEvent()) {
+      //  Secondly, process EPICS events, but not for online running,
+      //  because the EPICS events get messed up by our 32-bit to 64-bit
+      //  double ET system.
+      if (! eventbuffer.IsOnline() && eventbuffer.IsEPICSEvent()) {
         eventbuffer.FillEPICSData(epicsevent);
 	if (epicsevent.HasDataLoaded()){
 	  epicsevent.CalculateRunningValues();

--- a/Parity/main/QwParity.cc
+++ b/Parity/main/QwParity.cc
@@ -214,10 +214,17 @@ Int_t main(Int_t argc, Char_t* argv[])
     helicitypattern.ClearBurstSum();
 
 
-    //  Load the blinder seed from the database for this runlet.
-    #ifdef __USE_DATABASE__
-    helicitypattern.UpdateBlinder(&database);
-    #endif // __USE_DATABASE__
+
+    //  Load the blinder seed from a random number generator for online mode
+    if (eventbuffer.IsOnline() ){      
+      //helicitypattern.UpdateBlinder();//this routine will call update blinder mechanism using a random number
+    }else{
+      //  Load the blinder seed from the database for this runlet.
+#ifdef __USE_DATABASE__
+      helicitypattern.UpdateBlinder(&database);
+#endif // __USE_DATABASE__      
+    }
+    
 
     //  Find the first EPICS event and try to initialize
     //  the blinder, but only for disk files, not online.

--- a/Parity/main/QwParity.cc
+++ b/Parity/main/QwParity.cc
@@ -217,7 +217,7 @@ Int_t main(Int_t argc, Char_t* argv[])
 
     //  Load the blinder seed from a random number generator for online mode
     if (eventbuffer.IsOnline() ){      
-      //helicitypattern.UpdateBlinder();//this routine will call update blinder mechanism using a random number
+      helicitypattern.UpdateBlinder();//this routine will call update blinder mechanism using a random number
     }else{
       //  Load the blinder seed from the database for this runlet.
 #ifdef __USE_DATABASE__

--- a/Parity/src/QwBlinder.cc
+++ b/Parity/src/QwBlinder.cc
@@ -47,7 +47,7 @@ const TString QwBlinder::fStatusName[4] = {"Indeterminate", "NotBlindable",
 					   "Blindable", "BlindableFail"};
 
 // Maximum blinding asymmetry for additive blinding
-const Double_t QwBlinder::kDefaultMaximumBlindingAsymmetry = 0.06; // ppm
+const Double_t QwBlinder::kDefaultMaximumBlindingAsymmetry = 0.150; // ppm
 const Double_t QwBlinder::kDefaultMaximumBlindingFactor = 0.0; // [fraction]
 
 // Default seed, associated with seed_id 0
@@ -189,6 +189,11 @@ void QwBlinder::Update()
   //  Update the seed ID then tell us if it has changed.
   UInt_t old_seed_id = fSeedID;
   ReadRandomSeed();
+  //  Force the target to blindable, Wien to be forward,
+  //  and IHWP polarity to be +1
+  SetTargetBlindability(QwBlinder::kBlindable);
+  SetWienState(kWienForward);
+  SetIHWPPolarity(+1);
   // If the blinding seed has changed, re-initialize the blinder
   if (fSeedID != old_seed_id ||
       (fSeedID==0 && fSeed!=kDefaultSeed) ) {

--- a/Parity/src/QwBlinder.cc
+++ b/Parity/src/QwBlinder.cc
@@ -395,11 +395,11 @@ Int_t QwBlinder::ReadRandomSeed()
   // Initialize random number generator.
   srand(time(0));
   //get  a "random" positive integer 
-  fSeedID=rand();
+  
   for (int i = 0; i < 20; ++i) {
-        randomchar[i] = alphanum[fSeedID % strLen];
+    randomchar[i] = alphanum[rand() % strLen];
   }
-
+  fSeedID=rand();
   TString frandomSeed(randomchar);
   fSeed=frandomSeed;//a random string
   return fSeedID;

--- a/Parity/src/QwBlinder.cc
+++ b/Parity/src/QwBlinder.cc
@@ -181,6 +181,25 @@ void QwBlinder::Update(QwParityDB* db)
 #endif // __USE_DATABASE__
 
 /**
+ * Update the blinder status using a random number
+ *
+ */
+void QwBlinder::Update()
+{
+  //  Update the seed ID then tell us if it has changed.
+  UInt_t old_seed_id = fSeedID;
+  ReadRandomSeed();
+  // If the blinding seed has changed, re-initialize the blinder
+  if (fSeedID != old_seed_id ||
+      (fSeedID==0 && fSeed!=kDefaultSeed) ) {
+    QwWarning << "Changing blinder seed to " << fSeedID
+              << " from " << old_seed_id << "." << QwLog::endl;
+    InitBlinders(fSeedID);
+    InitTestValues(10);
+  }
+}
+
+/**
  * Update the blinder status with new external information
  *
  * @param detectors Current subsystem array
@@ -352,6 +371,39 @@ Int_t QwBlinder::ReadSeed(QwParityDB* db)
   return fSeedID;
 }
 #endif // __USE_DATABASE__
+
+/*!-----------------------------------------------------------
+ *------------------------------------------------------------
+ * Function to read the seed string generated utilizing a random number generator
+ *
+ * Parameters: none
+ *
+ * Return: Int_t 
+ *
+ *------------------------------------------------------------
+ *------------------------------------------------------------*/
+Int_t QwBlinder::ReadRandomSeed()
+{
+  static const Char_t alphanum[] =
+    "0123456789"
+    "!@#$%^&*"
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "abcdefghijklmnopqrstuvwxyz";
+
+  Int_t strLen = sizeof(alphanum) - 1;
+  Char_t randomchar[20];
+  // Initialize random number generator.
+  srand(time(0));
+  //get  a "random" positive integer 
+  fSeedID=rand();
+  for (int i = 0; i < 20; ++i) {
+        randomchar[i] = alphanum[fSeedID % strLen];
+  }
+
+  TString frandomSeed(randomchar);
+  fSeed=frandomSeed;//a random string
+  return fSeedID;
+}
 
 /*!-----------------------------------------------------------
  *------------------------------------------------------------


### PR DESCRIPTION
Modified blinder functionality to include the framework for random number generated blinder. Now if the Qwparity is run with Online flag, the Blinder will be based on a randomized seed string generated at `QwBlinder::ReadRandomSeed()`. 

In QwParity.cc, 
Load the blinder seed from a random number generator for online mode by checking 
    `if (eventbuffer.IsOnline() ){      
      helicitypattern.UpdateBlinder();//this routine will call update blinder mechanism using a random number
    }else{
      //  Load the blinder seed from the database for this runlet.
#ifdef __USE_DATABASE__
      helicitypattern.UpdateBlinder(&database);
#endif // __USE_DATABASE__      
    }`

Tested the new routine by explicitly calling random number blinding routine at the QwParity. In four runs I see two distinct blinder seeds printed in the command line.

Changing blinder seed to 799712133 from 0.
Changing blinder seed to 1984669649 from 0.
Changing blinder seed to 1445751709 from 0.
Changing blinder seed to 269095065 from 0.