### PR TITLE
Bugfix: Use ProcesssData instead of adding events in AccumulateRunningSum (MAJOR)

### DIFF
--- a/Parity/include/QwCorrelator.h
+++ b/Parity/include/QwCorrelator.h
@@ -37,8 +37,7 @@ class QwCorrelator : public VQwDataHandler, public MQwDataHandlerCloneable<QwCor
 		
   void unpackEvent();
 
-  void AccumulateRunningSum();
-  void ProcessData(){};
+  void ProcessData();
   void CalcCorrelations();
 		
  protected:

--- a/Parity/src/QwCorrelator.cc
+++ b/Parity/src/QwCorrelator.cc
@@ -62,7 +62,7 @@ void QwCorrelator::ParseConfigFile(QwParameterFile& file)
   corA.SetDisableHistogramFlag(fDisableHistos);
 }
 
-void QwCorrelator::AccumulateRunningSum()
+void QwCorrelator::ProcessData()
 {
   UInt_t error = 0;
 


### PR DESCRIPTION
The QwCorrelator class used AccumulateRunningSum() to add events to
the correlation matrices, but that function is now not called anymore.

Instead the class now calls the ProcessData function.

This now prints out the correct correlations and corrected means at the end of the run (1296):
```
Uncorrected Y values:
     mean          sig
Y0:  -0.00124514 +- 0.0167122
Y1:  -0.000134772 +- 0.00483523
Y2:  -0.000477551 +- 0.0199558
Y3:  -0.000166495 +- 0.00776414
Y4:  -0.000794472 +- 0.0184763
Y5:  -0.000186235 +- 0.00442468
Y6:  7.88221e-05 +- 0.0173341
Y7:  -0.000256982 +- 0.00752573
Y8:  0.000309415 +- 0.0422519
Y9:  0.000351179 +- 0.018208
Y10:  -0.0013971 +- 0.0677632
Y11:  0.250691 +- 18.9201
Y12:  -0.062942 +- 4.35373
Y13:  0.000499613 +- 1.22973
Y14:  0.716304 +- 53.9539
Y15:  0.456427 +- 36.879
Y16:  0.505054 +- 27.2152

Corrected Y values:
     mean          sig
Y0:  -0.00123571 +- 0.0165406
Y1:  -0.000107369 +- 0.0047495
Y2:  -0.000593582 +- 0.0189228
Y3:  -0.000133468 +- 0.00758671
Y4:  -0.000893304 +- 0.017566
Y5:  -0.000164463 +- 0.00431405
Y6:  8.21863e-05 +- 0.0169769
Y7:  -0.000215161 +- 0.00734926
Y8:  0.000316943 +- 0.0422446
Y9:  0.000354142 +- 0.0182077
Y10:  -0.00140879 +- 0.0677597
Y11:  0.263344 +- 18.9168
Y12:  -0.0664742 +- 4.35257
Y13:  0.00048292 +- 1.22971
Y14:  0.731428 +- 53.9525
Y15:  0.466494 +- 36.8782
Y16:  0.498801 +- 27.2145
```