### PR TITLE
Hotfix: Only close ROOT file if it has been opened successfully (MAJOR)

### DIFF
--- a/Parity/src/QwCorrelator.cc
+++ b/Parity/src/QwCorrelator.cc
@@ -59,16 +59,20 @@ QwCorrelator::QwCorrelator(const TString& name)
 
 QwCorrelator::~QwCorrelator()
 {
+  // Close output file
+  if (fAlphaOutputFile) {
+    fAlphaOutputFile->Write();
+    fAlphaOutputFile->Close();
+  } else
+    QwWarning << "Cannot close slopes ROOT file for "
+              << GetDataHandlerName() << QwLog::endl;
+
   if (fH1iv) { // only if previously allocated
     delete[] fH1iv;
     delete[] fH2iv;
     delete[] fH1dv;
     delete[] fH2dv;
   }
-
-  // Close output file
-  fAlphaOutputFile->Write();
-  fAlphaOutputFile->Close();
 }
 
 void QwCorrelator::ParseConfigFile(QwParameterFile& file)
@@ -302,7 +306,8 @@ void QwCorrelator::init(std::vector<std::string> ivName, std::vector<std::string
   nP = ivName.size();
   nY = dvName.size();
 
-  initHistos(ivName,dvName);
+  if (fDisableHistos == false)
+    initHistos(ivName,dvName);
 
   linReg.setDims(nP, nY);
   linReg.init();


### PR DESCRIPTION
It was possible to create a QwCorrelator data handler, but not fully
initialize it (e.g. the datahandlerarray_evt which isn't used at all yet
in QwParity doesn't ever call its ConstructTreeBranches method). This
resulted in null TFile pointer which is attempted to close. Result =
segfault on close.

Snuck in two other bug fixes which I thought might be at the cause:
- first close TFile, then delete histograms to make sure they make it
into the file
- only initialize histograms when disable-histos = false in the map file

Verified no segfault on default develop.