### PR TITLE
Bugfix: When checking histogram/tree prefix, allow stuff after diff_ (MINOR)

### DIFF
--- a/Parity/src/QwHelicity.cc
+++ b/Parity/src/QwHelicity.cc
@@ -1117,10 +1117,10 @@ void QwHelicity::SetFirstBits(UInt_t nbits, UInt_t seed)
 void QwHelicity::SetHistoTreeSave(const TString &prefix)
 {
   Ssiz_t len;
-  if (prefix == "diff_"
+  if (TRegexp("diff_").Index(prefix,&len) == 0
    || TRegexp("asym[1-9]*_").Index(prefix,&len) == 0)
     fHistoType = kHelNoSave;
-  else if (prefix == "yield_")
+  else if (TRegexp("yield_").Index(prefix,&len) == 0)
     fHistoType = kHelSavePattern;
   else
     fHistoType = kHelSaveMPS;


### PR DESCRIPTION
This ensures that "diff_|stat" is still treated as a diff_ for the
purpose of histogram/tree filling.

This is a bug fix for enabling pattern and burst histograms and trees,
since the type of histogram filling that is to be done changes between
constuction and filling (due to the use of "|stat"). In general, it may
have been a better idea to not reuse the same flag for histograms and
trees.