### PR TITLE
Bugfix: Don't apply disable tree so eagerly (MINOR)

### DIFF
--- a/Analysis/include/QwRootFile.h
+++ b/Analysis/include/QwRootFile.h
@@ -362,6 +362,7 @@ class QwRootFile {
 
     /// Create a new tree with name and description
     void NewTree(const std::string& name, const std::string& desc) {
+      if (IsTreeDisabled(name)) return;
       this->cd();
       QwRootTree *tree = 0;
       if (! HasTreeByName(name)) {

--- a/Analysis/src/QwRootFile.cc
+++ b/Analysis/src/QwRootFile.cc
@@ -255,11 +255,11 @@ void QwRootFile::ProcessOptions(QwOptions &options)
 
   // Options 'disable-mps' and 'disable-hel' for disabling
   // helicity window and helicity pattern output
-  if (options.GetValue<bool>("disable-mps-tree"))  DisableTree("evt");
-  if (options.GetValue<bool>("disable-pair-tree"))  DisableTree("pr");
-  if (options.GetValue<bool>("disable-hel-tree"))  DisableTree("mul");
-  if (options.GetValue<bool>("disable-burst-tree"))  DisableTree("burst");
-  if (options.GetValue<bool>("disable-slow-tree")) DisableTree("slow");
+  if (options.GetValue<bool>("disable-mps-tree"))  DisableTree("^evt$");
+  if (options.GetValue<bool>("disable-pair-tree"))  DisableTree("^pr$");
+  if (options.GetValue<bool>("disable-hel-tree"))  DisableTree("^mul$");
+  if (options.GetValue<bool>("disable-burst-tree"))  DisableTree("^burst$");
+  if (options.GetValue<bool>("disable-slow-tree")) DisableTree("^slow$");
 
   // Options 'num-accepted-events' and 'num-discarded-events' for
   // prescaling of the tree output

--- a/Analysis/src/QwRootFile.cc
+++ b/Analysis/src/QwRootFile.cc
@@ -173,6 +173,9 @@ void QwRootFile::DefineOptions(QwOptions &options)
 
   // Define the histogram and tree options
   options.AddOptions("ROOT output options")
+    ("disable-tree", po::value<std::vector<std::string>>()->composing(),
+     "disable output to tree regex");
+  options.AddOptions("ROOT output options")
     ("disable-trees", po::value<bool>()->default_bool_value(false),
      "disable output to all trees");
   options.AddOptions("ROOT output options")
@@ -250,6 +253,8 @@ void QwRootFile::ProcessOptions(QwOptions &options)
 
   // Options 'disable-trees' and 'disable-histos' for disabling
   // tree and histogram output
+  auto v = options.GetValueVector<std::string>("disable-tree");
+  std::for_each(v.begin(), v.end(), [&](const std::string& s){ this->DisableTree(s); });
   if (options.GetValue<bool>("disable-trees"))  DisableTree(".*");
   if (options.GetValue<bool>("disable-histos")) DisableHisto(".*");
 


### PR DESCRIPTION
Require `^mul$` instead of merely `mul` as disable tree name.

These are parsed as regex, and `mul` also matches `mulc` which is not intended. Now `--disable-hel-tree` will only remove the `mul` tree, not the `mulc` tree.

Also implements --disable-tree <regex> for other tree names, e.g. `--disable-tree _lr.\* --disable-tree .\*rst\$`
Escape when using shell wildcards (probably not needed in config files). Composing so options can be repeated.