### PR TITLE
Feature: LRB matrix math

### DIFF
--- a/Parity/include/LinReg_Bevington_Pebay.h
+++ b/Parity/include/LinReg_Bevington_Pebay.h
@@ -59,7 +59,7 @@ class LinRegBevPeb {
   virtual ~LinRegBevPeb() { };
 
   void solve();
-  bool failed() { return fGoodEventNumber <= 2; }
+  bool failed() { return fGoodEventNumber < nP + 1; }
 
   // after last event
   void printSummaryP() const;

--- a/Parity/include/LinReg_Bevington_Pebay.h
+++ b/Parity/include/LinReg_Bevington_Pebay.h
@@ -26,31 +26,33 @@ class LinRegBevPeb {
   Int_t fErrorFlag;             ///< is information valid
   Long64_t fGoodEventNumber;    ///< accumulated so far  
 
-  TMatrixD mA, mAsig;  ///< found slopes + their stand errors
-
   /// correlations
   TMatrixD mRPY, mRYP;
   TMatrixD mRPP, mRYY;
-  TMatrixD mRYYprime;
+  TMatrixD mRYYp;
 
   /// unnormalized covariances
   TMatrixD mVPY, mVYP;
   TMatrixD mVPP, mVYY;
-  TMatrixD mVYYprime;
+  TMatrixD mVYYp;
+  /// variances
+  TVectorD mVP, mVY;
+  TVectorD mVYp;
 
   /// normalized covariances
-  TMatrixD sigXY, sigYX;
-  TMatrixD sigXX, sigYY;
-  TMatrixD sigYYprime;
+  TMatrixD mSPY, mSYP;
+  TMatrixD mSPP, mSYY;
+  TMatrixD mSYYp;
+  /// sigmas
+  TVectorD mSP, mSY;
+  TVectorD mSYp;
 
   /// mean values
-  TVectorD mMP, mMY, mMYprime;
+  TVectorD mMP, mMY, mMYp;
 
-  /// sigmas
-  TVectorD sigX, sigY, sigYprime;
 
   /// slopes
-  TMatrixD Axy, Ayx;
+  TMatrixD Axy, Ayx, dAxy, dAyx; // found slopes and their standard errors
 
  public:
 
@@ -72,7 +74,7 @@ class LinRegBevPeb {
   void print();
   void init();
   void clear();
-  void setDims(int a, int b){ nP=a; nY=b;}
+  void setDims(int a, int b){ nP = a; nY = b;}
 
   /// Get mean value of a variable, returns error code
   Int_t getMeanP(const int i, Double_t &mean) const;

--- a/Parity/include/QwCorrelator.h
+++ b/Parity/include/QwCorrelator.h
@@ -116,11 +116,8 @@ class QwCorrelator : public VQwDataHandler, public MQwDataHandlerCloneable<QwCor
 		
   int nP, nY;
 
-  // histograms
-  enum {mxHA=4};
-  TH1D* hA[mxHA];
-
   // monitoring histos for iv & dv
+  std::vector<TH1D> fHnames;
   std::vector<TH1D> fH1iv;
   std::vector<TH1D> fH1dv;
   std::vector<std::vector<TH2D>> fH2iv;

--- a/Parity/src/LinReg_Bevington_Pebay.cc
+++ b/Parity/src/LinReg_Bevington_Pebay.cc
@@ -39,34 +39,37 @@ void LinRegBevPeb::init()
 {
   mMP.ResizeTo(nP);
   mMY.ResizeTo(nY);
-  mMYprime.ResizeTo(nY);
+  mMYp.ResizeTo(nY);
 
   mVPP.ResizeTo(nP,nP);
   mVPY.ResizeTo(nP,nY);
   mVYP.ResizeTo(nY,nP);
   mVYY.ResizeTo(nY,nY);
-  mVYYprime.ResizeTo(nY,nY);
+  mVYYp.ResizeTo(nY,nY);
+  mVP.ResizeTo(nP);
+  mVY.ResizeTo(nY);
+  mVYp.ResizeTo(nY);
 
-  sigXX.ResizeTo(mVPP);
-  sigXY.ResizeTo(mVPY);
-  sigYX.ResizeTo(mVYP);
-  sigYY.ResizeTo(mVYY);
-  sigYYprime.ResizeTo(mVYYprime);
+  mSPP.ResizeTo(mVPP);
+  mSPY.ResizeTo(mVPY);
+  mSYP.ResizeTo(mVYP);
+  mSYY.ResizeTo(mVYY);
+  mSYYp.ResizeTo(mVYYp);
 
-  mA.ResizeTo(nP,nY);
-  mAsig.ResizeTo(mA);
   Axy.ResizeTo(nP,nY);
   Ayx.ResizeTo(nY,nP);
+  dAxy.ResizeTo(Axy);
+  dAyx.ResizeTo(Ayx);
 
-  sigX.ResizeTo(nP);
-  sigY.ResizeTo(nY);
-  sigYprime.ResizeTo(nY);
+  mSP.ResizeTo(nP);
+  mSY.ResizeTo(nY);
+  mSYp.ResizeTo(nY);
 
   mRPP.ResizeTo(mVPP);
   mRPY.ResizeTo(mVPY);
   mRYP.ResizeTo(mVYP);
   mRYY.ResizeTo(mVYY);
-  mRYYprime.ResizeTo(mVYYprime);
+  mRYYp.ResizeTo(mVYYp);
 
   fGoodEventNumber = 0;
 }
@@ -75,34 +78,37 @@ void LinRegBevPeb::clear()
 {
   mMP.Zero();
   mMY.Zero();
-  mMYprime.Zero();
+  mMYp.Zero();
 
   mVPP.Zero();
   mVPY.Zero();
   mVYP.Zero();
   mVYY.Zero();
-  mVYYprime.Zero();
+  mVYYp.Zero();
+  mVP.Zero();
+  mVY.Zero();
+  mVYp.Zero();
 
-  sigXX.Zero();
-  sigXY.Zero();
-  sigYX.Zero();
-  sigYY.Zero();
-  sigYYprime.Zero();
+  mSPP.Zero();
+  mSPY.Zero();
+  mSYP.Zero();
+  mSYY.Zero();
+  mSYYp.Zero();
 
-  mA.Zero();
-  mAsig.Zero();
   Axy.Zero();
   Ayx.Zero();
+  dAxy.Zero();
+  dAyx.Zero();
 
-  sigX.Zero();
-  sigY.Zero();
-  sigYprime.Zero();
+  mSP.Zero();
+  mSY.Zero();
+  mSYp.Zero();
 
   mRPP.Zero();
   mRPY.Zero();
   mRYP.Zero();
   mRYY.Zero();
-  mRYYprime.Zero();
+  mRYYp.Zero();
 
   fErrorFlag = -1;
   fGoodEventNumber = 0;
@@ -119,7 +125,7 @@ void LinRegBevPeb::print()
   QwMessage << "VPP:"; mVPP.Print();
   QwMessage << "VPY:"; mVPY.Print();
   QwMessage << "VYY:"; mVYY.Print();
-  QwMessage << "VYYprime:"; mVYYprime.Print();
+  QwMessage << "VYYprime:"; mVYYp.Print();
 }
 
 
@@ -229,7 +235,7 @@ Int_t LinRegBevPeb::getMeanYprime(const int i, Double_t &mean) const
   mean=-1e50;
   if(i<0 || i >= nY ) return -1;
   if( fGoodEventNumber<1) return -3;
-  mean = mMYprime(i);    return 0;
+  mean = mMYp(i);    return 0;
 }
 
 
@@ -263,7 +269,7 @@ Int_t LinRegBevPeb::getSigmaYprime(const int i, Double_t &sigma) const
   sigma=-1e50;
   if(i<0 || i >= nY ) return -1;
   if( fGoodEventNumber<2) return -3;
-  sigma=sqrt(mVYYprime(i,i)/(fGoodEventNumber-1.));
+  sigma=sqrt(mVYYp(i,i)/(fGoodEventNumber-1.));
   return 0;
 }
 
@@ -372,8 +378,8 @@ void LinRegBevPeb::printSummaryAlphas() const
   for (int iy = 0; iy <nY; iy++) {
     QwMessage << Form("dv=Y%d: ",iy)<<QwLog::endl;
     for (int j = 0; j < nP; j++) {
-      double val=mA(j,iy);
-      double err=mAsig(j,iy);
+      double val=Axy(j,iy);
+      double err=dAxy(j,iy);
       double nSig=val/err;
       char x=' ';
       if(fabs(nSig)>3.) x='*';
@@ -420,7 +426,7 @@ void LinRegBevPeb::printSummaryMeansWithUnc() const
   QwMessage << "Uncorrected Y values:" << QwLog::endl;
   QwMessage << "     mean          sig" << QwLog::endl;
   for (int i = 0; i < nY; i++){
-    QwMessage << "Y" << i << ":  " << mMY(i) << " +- " << sigY(i) << QwLog::endl;
+    QwMessage << "Y" << i << ":  " << mMY(i) << " +- " << mSY(i) << QwLog::endl;
   }
   QwMessage << QwLog::endl;
 }
@@ -433,7 +439,7 @@ void LinRegBevPeb::printSummaryMeansWithUncCorrected() const
   QwMessage << "Corrected Y values:" << QwLog::endl;
   QwMessage << "     mean          sig" << QwLog::endl;
   for (int i = 0; i < nY; i++){
-    QwMessage << "Y" << i << ":  " << mMYprime(i) << " +- " << sigYprime(i) << QwLog::endl;
+    QwMessage << "Y" << i << ":  " << mMYp(i) << " +- " << mSYp(i) << QwLog::endl;
   }
   QwMessage << QwLog::endl;
 }
@@ -443,21 +449,29 @@ void LinRegBevPeb::printSummaryMeansWithUncCorrected() const
 //==========================================================
 void LinRegBevPeb::solve()
 {
-  TMatrixD invmVPP(TMatrixD::kUnit, mVPP);
-  invmVPP *= TMatrixDDiag(mVPP);
-  invmVPP.Invert();
-  invmVPP.Sqrt();
+  // off-diagonal raw covariance
+  mVYP.Transpose(mVPY);
 
-  TMatrixD invmVYY(TMatrixD::kUnit, mVYY);
-  invmVYY *= TMatrixDDiag(mVYY);
-  invmVYY.Invert();
-  invmVYY.Sqrt();
+  // diagonal variances
+  mVP = TMatrixDDiag(mVPP); mVP.Sqrt();
+  mVY = TMatrixDDiag(mVYY); mVY.Sqrt();
 
-  mRPP = invmVPP * mVPP * invmVPP;
-  mRYY = invmVYY * mVYY * invmVYY;
-  mRPY = invmVPP * mVPY * invmVYY;
+  // correlation matrices
+  mRPP = mVPP; mRPP.NormByColumn(mVP); mRPP.NormByRow(mVP);
+  mRYY = mVYY; mRYY.NormByColumn(mVY); mRYY.NormByRow(mVY);
+  mRPY = mVPY; mRPY.NormByColumn(mVP); mRPY.NormByRow(mVY);
 
-  // Warn if determinant close to zero (heuristic)
+  /// normalized covariances
+  mSYY = mVYY * (1.0 / (fGoodEventNumber - 1.));
+  mSPP = mVPP * (1.0 / (fGoodEventNumber - 1.));
+  mSPY = mVPY * (1.0 / (fGoodEventNumber - 1.));
+  mSYP.Transpose(mSPY);
+
+  // uncertainties on the means
+  mSP = TMatrixDDiag(mSPP); mSP.Sqrt();
+  mSY = TMatrixDDiag(mSYY); mSY.Sqrt();
+
+  // Warn if correlation matrix determinant close to zero (heuristic)
   if (mRPP.Determinant() < std::pow(10,-nP)) {
     QwWarning << "LRB: correlation matrix nearly singular, "
               << "determinant = " << mRPP.Determinant()
@@ -472,74 +486,37 @@ void LinRegBevPeb::solve()
               << QwLog::endl;
     return;
   }
-  TMatrixD invRPP(TMatrixD::kInverted, mRPP);
-
-  TMatrixD Djy; Djy.ResizeTo(mRPY);
-  Djy.Mult(invRPP,mRPY);
-
-  for (int iy = 0; iy <nY; iy++) {
-    double Sy;
-    if (getSigmaY(iy,Sy) < 0) QwWarning << "LRB::getSigmaY failed" << QwLog::endl;
-    for (int ip = 0; ip <nP; ip++) {
-      double Sk;
-      if (getSigmaP(ip,Sk) < 0) QwWarning << "LRB::getSigmaP failed" << QwLog::endl;
-      mA(ip,iy)= Djy(ip,iy) * Sy / Sk;
-    }
-  }
-
-  /// normalized covariances
-  sigYY = mVYY * (1.0 / (fGoodEventNumber - 1.));
-  sigXX = mVPP * (1.0 / (fGoodEventNumber - 1.));
-  sigXY = mVPY * (1.0 / (fGoodEventNumber - 1.));
-  sigYX.Transpose(sigXY);
-
   // slopes
-  Axy = mA;
+  TMatrixD invRPP(TMatrixD::kInverted, mRPP);
+  Axy = TMatrixD(invRPP, TMatrixD::kMult, mRPY);
+  Axy.NormByColumn(mSP); // divide
+  Axy.NormByRow(mSY, ""); // mult
   Ayx.Transpose(Axy);
 
   // new means
-  mMYprime = mMY - Ayx * mMP;
+  mMYp = mMY - Ayx * mMP;
 
-  // new covariance
-  mVYP.Transpose(mVPY);
-  mVYYprime = mVYY + Ayx * mVPP * Axy - (Ayx * mVPY + mVYP * Axy);
+  // new raw covariance
+  mVYYp = mVYY + Ayx * mVPP * Axy - (Ayx * mVPY + mVYP * Axy);
+  // new variances
+  mVYp = TMatrixDDiag(mVYYp); mVYp.Sqrt();
 
   // new normalized covariance
-  sigYYprime = sigYY + Ayx * sigXX * Axy - (Ayx * sigXY + sigYX * Axy);
+  mSYYp = mSYY + Ayx * mSPP * Axy - (Ayx * mSPY + mSYP * Axy);
+  // uncertainties on the new means
+  mSYp = TMatrixDDiag(mSYYp); mSYp.Sqrt();
 
-  // old sigmas
-  sigX = TMatrixDDiag(sigXX);
-  sigX.Sqrt();
-  sigY = TMatrixDDiag(sigYY);
-  sigY.Sqrt();
-
-  // new sigmas
-  sigYprime = TMatrixDDiag(sigYYprime);
-  sigYprime.Sqrt();
-
-  // invert sigmas and determine correlation matrix
-  TMatrixD invsigYprime(TMatrixD::kUnit, sigYYprime);
-  invsigYprime *= TMatrixDDiag(sigYYprime);
-  invsigYprime.Invert();
-  invsigYprime.Sqrt();
-  mRYYprime = invsigYprime * sigYYprime * invsigYprime;
+  // new correlation matrix
+  mRYYp = mVYYp; mRYYp.NormByColumn(mVYp); mRYYp.NormByRow(mVYp);
 
   // slope uncertainties
   double norm = 1. / (fGoodEventNumber - nP - 1);
-  for (int iy = 0; iy < nY; iy++) {
-    /* compute s^2= Vy + Vx -2*Vxy 
-       where Vy~var(y), Vx~var(x), Vxy~cov(y,x)     */
-    double Vx=0,Vxy=0;
-    for (int j = 0; j < nP; j++) {
-      for (int k = 0; k < nP; k++)
-	Vx += sigXX(j,k) * mA(j,iy) * mA(k,iy);
-      Vxy += sigXY(j,iy) * mA(j,iy);
-    }
-    double s2 = sigY(iy) * sigY(iy) + Vx - 2 * Vxy; // consistent w/ Bevington
-    for (int j = 0; j < nP; j++) {
-      mAsig(j,iy)= sqrt(norm * invRPP(j,j) * s2) / sigX(j);
-    }
-  }
+  dAxy.Zero();
+  dAxy.Rank1Update(TMatrixDDiag(invRPP), TMatrixDDiag(mRYYp), norm); // diag mRYYp = row of ones
+  dAxy.Sqrt();
+  dAxy.NormByColumn(mSP); // divide
+  dAxy.NormByRow(mSYp, ""); // mult
+  dAyx.Transpose(dAxy);
 
   fErrorFlag = 0;
 }

--- a/Parity/src/QwCorrelator.cc
+++ b/Parity/src/QwCorrelator.cc
@@ -558,12 +558,13 @@ void QwCorrelator::ConstructHistograms(TDirectory *folder, TString &prefix)
   }
 
   // store list of names to be archived
-  hA[0] = new TH1D("NamesIV",Form("IV name list nIV=%d",nP),nP,0,1);
+  fHnames.resize(2);
+  fHnames[0] = TH1D("NamesIV",Form("IV name list nIV=%d",nP),nP,0,1);
   for (int i = 0; i < nP; i++)
-    hA[0]->Fill(fIndependentName[i].c_str(),1.*i);
-  hA[1] = new TH1D("NamesDV",Form("DV name list nIV=%d",nY),nY,0,1);
+    fHnames[0].Fill(fIndependentName[i].c_str(),1.*i);
+  fHnames[1] = TH1D("NamesDV",Form("DV name list nIV=%d",nY),nY,0,1);
   for (int i = 0; i < nY; i++)
-    hA[1]->Fill(fDependentName[i].c_str(),i*1.);
+    fHnames[1].Fill(fDependentName[i].c_str(),i*1.);
 }
 
 /// \brief Fill the histograms

--- a/Parity/src/QwCorrelator.cc
+++ b/Parity/src/QwCorrelator.cc
@@ -449,34 +449,34 @@ void QwCorrelator::ConstructTreeBranches(
     tree->Branch(bn(n),pv(v),lv(v,n));
   };
 
-  branchm(fTree,linReg.mA,    "A");
-  branchm(fTree,linReg.mAsig, "dA");
+  branchm(fTree,linReg.Axy,  "A");
+  branchm(fTree,linReg.dAxy, "dA");
 
-  branchm(fTree,linReg.mVPP,      "VPP");
-  branchm(fTree,linReg.mVPY,      "VPY");
-  branchm(fTree,linReg.mVYP,      "VYP");
-  branchm(fTree,linReg.mVYY,      "VYY");
-  branchm(fTree,linReg.mVYYprime, "VYYp");
+  branchm(fTree,linReg.mVPP,  "VPP");
+  branchm(fTree,linReg.mVPY,  "VPY");
+  branchm(fTree,linReg.mVYP,  "VYP");
+  branchm(fTree,linReg.mVYY,  "VYY");
+  branchm(fTree,linReg.mVYYp, "VYYp");
 
-  branchm(fTree,linReg.sigXX,     "SPP");
-  branchm(fTree,linReg.sigXY,     "SPY");
-  branchm(fTree,linReg.sigYX,     "SYP");
-  branchm(fTree,linReg.sigYY,     "SYY");
-  branchm(fTree,linReg.sigYYprime,"SYYp");
+  branchm(fTree,linReg.mSPP,  "SPP");
+  branchm(fTree,linReg.mSPY,  "SPY");
+  branchm(fTree,linReg.mSYP,  "SYP");
+  branchm(fTree,linReg.mSYY,  "SYY");
+  branchm(fTree,linReg.mSYYp, "SYYp");
 
-  branchm(fTree,linReg.mRPP,      "RPP");
-  branchm(fTree,linReg.mRPY,      "RPY");
-  branchm(fTree,linReg.mRYP,      "RYP");
-  branchm(fTree,linReg.mRYY,      "RYY");
-  branchm(fTree,linReg.mRYYprime, "RYYp");
+  branchm(fTree,linReg.mRPP,  "RPP");
+  branchm(fTree,linReg.mRPY,  "RPY");
+  branchm(fTree,linReg.mRYP,  "RYP");
+  branchm(fTree,linReg.mRYY,  "RYY");
+  branchm(fTree,linReg.mRYYp, "RYYp");
 
-  branchv(fTree,linReg.mMP,      "MP");
-  branchv(fTree,linReg.mMY,      "MY");
-  branchv(fTree,linReg.mMYprime, "MYp");
+  branchv(fTree,linReg.mMP,  "MP");
+  branchv(fTree,linReg.mMY,  "MY");
+  branchv(fTree,linReg.mMYp, "MYp");
 
-  branchv(fTree,linReg.sigX,     "dMP");
-  branchv(fTree,linReg.sigY,     "dMY");
-  branchv(fTree,linReg.sigYprime,"dMYp");
+  branchv(fTree,linReg.mSP,  "dMP");
+  branchv(fTree,linReg.mSY,  "dMY");
+  branchv(fTree,linReg.mSYp, "dMYp");
 
   // Create alpha and alias files
   OpenAlphaFile(treeprefix);
@@ -600,17 +600,17 @@ void QwCorrelator::WriteAlphaFile()
   if (fAlphaOutputFile) fAlphaOutputFile->cd();
 
   // Write objects
-  linReg.mA.Write("slopes");
-  linReg.mAsig.Write("sigSlopes");
+  linReg.Axy.Write("slopes");
+  linReg.dAxy.Write("sigSlopes");
 
   linReg.mRPP.Write("IV_IV_correlation");
   linReg.mRPY.Write("IV_DV_correlation");
   linReg.mRYY.Write("DV_DV_correlation");
-  linReg.mRYYprime.Write("DV_DV_correlation_prime");
+  linReg.mRYYp.Write("DV_DV_correlation_prime");
 
   linReg.mMP.Write("IV_mean");
   linReg.mMY.Write("DV_mean");
-  linReg.mMYprime.Write("DV_mean_prime");
+  linReg.mMYp.Write("DV_mean_prime");
 
   // number of events
   TMatrixD Mstat(1,1);
@@ -628,32 +628,32 @@ void QwCorrelator::WriteAlphaFile()
   hdv.Write();
 
   // sigmas
-  linReg.sigX.Write("IV_sigma");
-  linReg.sigY.Write("DV_sigma");
-  linReg.sigYprime.Write("DV_sigma_prime");
+  linReg.mSP.Write("IV_sigma");
+  linReg.mSY.Write("DV_sigma");
+  linReg.mSYp.Write("DV_sigma_prime");
 
   // raw covariances
   linReg.mVPP.Write("IV_IV_rawVariance");
   linReg.mVPY.Write("IV_DV_rawVariance");
   linReg.mVYY.Write("DV_DV_rawVariance");
-  linReg.mVYYprime.Write("DV_DV_rawVariance_prime");
+  linReg.mVYYp.Write("DV_DV_rawVariance_prime");
   TVectorD mVY2(TMatrixDDiag(linReg.mVYY));
   mVY2.Write("DV_rawVariance");
   TVectorD mVP2(TMatrixDDiag(linReg.mVPP));
   mVP2.Write("IV_rawVariance");
-  TVectorD mVY2prime(TMatrixDDiag(linReg.mVYYprime));
+  TVectorD mVY2prime(TMatrixDDiag(linReg.mVYYp));
   mVY2prime.Write("DV_rawVariance_prime");
 
   // normalized covariances
-  linReg.sigXX.Write("IV_IV_normVariance");
-  linReg.sigXY.Write("IV_DV_normVariance");
-  linReg.sigYY.Write("DV_DV_normVariance");
-  linReg.sigYYprime.Write("DV_DV_normVariance_prime");
-  TVectorD sigY2(TMatrixDDiag(linReg.sigYY));
+  linReg.mSPP.Write("IV_IV_normVariance");
+  linReg.mSPY.Write("IV_DV_normVariance");
+  linReg.mSYY.Write("DV_DV_normVariance");
+  linReg.mSYYp.Write("DV_DV_normVariance_prime");
+  TVectorD sigY2(TMatrixDDiag(linReg.mSYY));
   sigY2.Write("DV_normVariance");
-  TVectorD sigX2(TMatrixDDiag(linReg.sigXX));
+  TVectorD sigX2(TMatrixDDiag(linReg.mSPP));
   sigX2.Write("IV_normVariance");
-  TVectorD sigY2prime(TMatrixDDiag(linReg.sigYYprime));
+  TVectorD sigY2prime(TMatrixDDiag(linReg.mSYYp));
   sigY2prime.Write("DV_normVariance_prime");
 
   linReg.Axy.Write("A_xy");
@@ -729,7 +729,7 @@ void QwCorrelator::WriteAliasFile()
     fAliasOutputFile << Form("  tree->SetAlias(\"reg_%s\",",fDependentFull[i].Data()) << std::endl;
     fAliasOutputFile << Form("         \"%s",fDependentFull[i].Data());
     for (int j = 0; j < nP; j++) {
-      fAliasOutputFile << Form("%+.4e*%s", -linReg.mA(j,i), fIndependentFull[j].Data());
+      fAliasOutputFile << Form("%+.4e*%s", -linReg.Axy(j,i), fIndependentFull[j].Data());
     }
     fAliasOutputFile << "\");" << std::endl;
   }


### PR DESCRIPTION
Finally figured out how the matrix math expressions for the uncertainties on the slopes:
```
  dAxy.Zero();
  dAxy.Rank1Update(TMatrixDDiag(invRPP), TMatrixDDiag(mRYYp), norm); // diag mRYYp = row of ones
  dAxy.Sqrt();
  dAxy.NormByColumn(mSP); // divide
  dAxy.NormByRow(mSYp, ""); // mult
```
which is mean square error / ndof * R^-1. TMatrixD is designed for (RPN-like) in-place operations, hence the weird order of operations.

(Really, these were a few loose ends that weren't committed to feature-burst-regression before Paul merged that into develop.)