### PR TITLE
Bugfix: Correct coda event number in burst (MINOR)

### DIFF
--- a/Analysis/src/QwSubsystemArray.cc
+++ b/Analysis/src/QwSubsystemArray.cc
@@ -550,14 +550,13 @@ void  QwSubsystemArray::ConstructBranchAndVector(
   values.push_back(0.0);
   values.push_back(0.0);
   values.push_back(0.0);
-  if (prefix == "" || prefix == "yield_") {
+  if (prefix == "" || prefix.Index("yield_") == 0) {
     tree->Branch("CodaEventNumber",&(values[fTreeArrayIndex]),"CodaEventNumber/D");
     tree->Branch("CodaEventType",&(values[fTreeArrayIndex+1]),"CodaEventType/D");
     tree->Branch("Coda_CleanData",&(values[fTreeArrayIndex+2]),"Coda_CleanData/D");
     tree->Branch("Coda_ScanData1",&(values[fTreeArrayIndex+3]),"Coda_ScanData1/D");
     tree->Branch("Coda_ScanData2",&(values[fTreeArrayIndex+4]),"Coda_ScanData2/D");
   }
-  
   for (iterator subsys = begin(); subsys != end(); ++subsys) {
     VQwSubsystem* subsys_ptr = dynamic_cast<VQwSubsystem*>(subsys->get());
     subsys_ptr->ConstructBranchAndVector(tree, prefix, values);

--- a/Parity/src/QwSubsystemArrayParity.cc
+++ b/Parity/src/QwSubsystemArrayParity.cc
@@ -109,7 +109,8 @@ QwSubsystemArrayParity& QwSubsystemArrayParity::operator= (const QwSubsystemArra
 QwSubsystemArrayParity& QwSubsystemArrayParity::operator+= (const QwSubsystemArrayParity &value)
 {
   if (!value.empty()){
-
+    fCodaEventNumber = (fCodaEventNumber == 0) ? value.fCodaEventNumber :
+        std::min(fCodaEventNumber, value.fCodaEventNumber);
     if (this->size() == value.size()){
       this->fErrorFlag|=value.fErrorFlag;
       for(size_t i=0;i<value.size();i++){
@@ -148,7 +149,8 @@ QwSubsystemArrayParity& QwSubsystemArrayParity::operator+= (const QwSubsystemArr
 QwSubsystemArrayParity& QwSubsystemArrayParity::operator-= (const QwSubsystemArrayParity &value)
 {
   if (!value.empty()){
-
+    fCodaEventNumber = (fCodaEventNumber == 0) ? value.fCodaEventNumber :
+        std::min(fCodaEventNumber, value.fCodaEventNumber);
     if (this->size() == value.size()){
       this->fErrorFlag|=value.fErrorFlag;
       for(size_t i=0;i<value.size();i++){
@@ -183,7 +185,6 @@ void QwSubsystemArrayParity::Sum(
   const QwSubsystemArrayParity &value1,
   const QwSubsystemArrayParity &value2)
 {
-
   if (!value1.empty()&& !value2.empty()){
     *(this)  = value1;
     *(this) += value2;
@@ -263,7 +264,9 @@ void QwSubsystemArrayParity::AccumulateRunningSum(const QwSubsystemArrayParity& 
   if (!value.empty()) {
     if (this->size() == value.size()) {
       if (value.GetEventcutErrorFlag()==0){//do running sum only if error flag is zero. This way will prevent any Beam Trip(in ev mode 3) related events going into the running sum.
-	for (size_t i = 0; i < value.size(); i++) {
+        fCodaEventNumber = (fCodaEventNumber == 0) ? value.fCodaEventNumber :
+            std::min(fCodaEventNumber, value.fCodaEventNumber);
+        for (size_t i = 0; i < value.size(); i++) {
 	  if (value.at(i)==NULL || this->at(i)==NULL) {
 	    //  Either the value or the destination subsystem
 	    //  are null


### PR DESCRIPTION
Propagate CODA event number in +=, -= and accumulators

In particular, try to find the smallest non-zero CODA event number. This means that now
```
mul->Scan("CodaEventNumber")
burst->Scan("CodaEventNumber")
```
all return the right result (curiously even the first one was wrong since it returned the CODA event number of the first POSITIVE helicity event).

Possibly related to #217 in a sense that the reason why mps_counter is set to the value at the first positive helicity windows is the same as here. We only set some variables when we execute operator=. The order of operations for helicity pattern quantities is operator= on first positive helicity, operator+= on all the next, then operator= on the first negative, operator+= on all the next, then Sum, Difference on the positive and negative, which does operator= on the positive and then operator+= or operator-= on the negative. In short, first positive is what ends up getting assigned... tl;dr, use CodaEventNumber instead of mps_counter.

At this point only CODA event number is propagated correctly, so event type, scan data, clean data, etc, including the quantities in QwHelicity will still be incorrect.