### PR TITLE
Changes to how pairs/patterns with blinding errors appear in ROOT files.

### DIFF
--- a/Analysis/src/QwADC18_Channel.cc
+++ b/Analysis/src/QwADC18_Channel.cc
@@ -1132,7 +1132,7 @@ void QwADC18_Channel::Blind(const QwBlinder *blinder)
       blinder->BlindValue(fValue);
     } else {
       blinder->ModifyThisErrorCode(fErrorFlag);
-      fValue = 0.0;
+      fValue = QwBlinder::kValue_BlinderFail;
     }
   }
 }
@@ -1149,7 +1149,7 @@ void QwADC18_Channel::Blind(const QwBlinder *blinder, const QwADC18_Channel& yie
       blinder->BlindValue(fValue, yield.fValue);
     } else {
       blinder->ModifyThisErrorCode(fErrorFlag);//update the HW error code
-      fValue = 0.0;
+      fValue = QwBlinder::kValue_BlinderFail * yield.fValue;
     }
   }
 }

--- a/Analysis/src/QwVQWK_Channel.cc
+++ b/Analysis/src/QwVQWK_Channel.cc
@@ -1568,8 +1568,9 @@ void QwVQWK_Channel::Blind(const QwBlinder *blinder)
       blinder->BlindValue(fHardwareBlockSum);
     } else {
       blinder->ModifyThisErrorCode(fErrorFlag);
-      for (Int_t i = 0; i < fBlocksPerEvent; i++)  fBlock[i] = 0.0;
-      fHardwareBlockSum = 0.0;
+      for (Int_t i = 0; i < fBlocksPerEvent; i++)
+	fBlock[i] = QwBlinder::kValue_BlinderFail;
+      fHardwareBlockSum =  QwBlinder::kValue_BlinderFail;
     }
   }
   return;
@@ -1589,8 +1590,9 @@ void QwVQWK_Channel::Blind(const QwBlinder *blinder, const QwVQWK_Channel& yield
       blinder->BlindValue(fHardwareBlockSum, yield.fHardwareBlockSum);
     } else {
       blinder->ModifyThisErrorCode(fErrorFlag);//update the HW error code
-      for (Int_t i = 0; i < fBlocksPerEvent; i++)  fBlock[i] = 0.0;
-      fHardwareBlockSum = 0.0;
+      for (Int_t i = 0; i < fBlocksPerEvent; i++)
+	fBlock[i] = QwBlinder::kValue_BlinderFail * yield.fBlock[i];
+      fHardwareBlockSum = QwBlinder::kValue_BlinderFail * yield.fHardwareBlockSum;
     }
   }
   return;

--- a/Parity/include/QwBlinder.h
+++ b/Parity/include/QwBlinder.h
@@ -85,6 +85,7 @@ class QwBlinder {
   
   ///  Error flag value 
   static const UInt_t kErrorFlag_BlinderFail = 0x200;
+  constexpr static const Double_t kValue_BlinderFail   = -1.0;
 
   static void DefineOptions(QwOptions &options);
 

--- a/Parity/src/QwHelicityPattern.cc
+++ b/Parity/src/QwHelicityPattern.cc
@@ -392,6 +392,10 @@ void  QwHelicityPattern::CalculatePairAsymmetry()
       //  can propagate to the global error.
       fPairDifference.UpdateErrorFlag();
       fPairYield.UpdateErrorFlag(fPairDifference);
+      if (! fBlinder.IsBlinderOkay()){
+	fPairYield.UpdateErrorFlag(QwBlinder::kErrorFlag_BlinderFail);
+	fPairDifference.UpdateErrorFlag(QwBlinder::kErrorFlag_BlinderFail);
+      }
     }
     fPairAsymmetry.Ratio(fPairDifference,fPairYield);
     fPairAsymmetry.IncrementErrorCounters();
@@ -551,6 +555,10 @@ void  QwHelicityPattern::CalculateAsymmetry()
       //  can propagate to the global error.
       fDifference.UpdateErrorFlag();
       fYield.UpdateErrorFlag(fDifference);
+      if (! fBlinder.IsBlinderOkay()){
+	fYield.UpdateErrorFlag(QwBlinder::kErrorFlag_BlinderFail);
+	fDifference.UpdateErrorFlag(QwBlinder::kErrorFlag_BlinderFail);
+      }
     }
     fAsymmetry.Ratio(fDifference,fYield);
     fAsymmetry.IncrementErrorCounters();


### PR DESCRIPTION
For pairs/patterns that have a blinding failure, blindable asymmetries
will be set to a value of -1 in natural units (1.e. -1000000 ppm)
instead of zero.

Pairs/patterns with a blinding failure will have the ErrorFlag set to
include the blinding error bit instead of just having that appear in
the individual device error codes.
The blindable asymmetries already had their individual error codes
marked in the case of blinding errors, but this now will have the
entire pair/pattern so marked.