### PR TITLE
Hotfix adjustable burp extent

### DIFF
--- a/Analysis/include/VQwHardwareChannel.h
+++ b/Analysis/include/VQwHardwareChannel.h
@@ -39,6 +39,8 @@ public:
   VQwHardwareChannel(const VQwHardwareChannel& value, VQwDataElement::EDataToSave datatosave);
   virtual ~VQwHardwareChannel() { };
 
+  void ProcessOptions();
+
   virtual VQwHardwareChannel* Clone() = 0;
 
   using VQwDataElement::UpdateErrorFlag;

--- a/Analysis/src/VQwHardwareChannel.cc
+++ b/Analysis/src/VQwHardwareChannel.cc
@@ -6,6 +6,7 @@
 #include "QwDBInterface.h"
 #endif
 #include "QwParameterFile.h"
+#include "QwOptions.h"
 
 VQwHardwareChannel::VQwHardwareChannel():
   fNumberOfDataWords(0),
@@ -17,6 +18,8 @@ VQwHardwareChannel::VQwHardwareChannel():
   fErrorConfigFlag = 0;
   fBurpHoldoff = 10;
   fBurpThreshold = -1.0;
+  
+  ProcessOptions();
 }
 
 VQwHardwareChannel::VQwHardwareChannel(const VQwHardwareChannel& value)
@@ -61,6 +64,10 @@ VQwHardwareChannel::VQwHardwareChannel(const VQwHardwareChannel& value, VQwDataE
 {
 }
 
+void VQwHardwareChannel::ProcessOptions(){
+  if (gQwOptions.HasValue("burp.holdoff"))
+    fBurpHoldoff=gQwOptions.GetValue<int>("burp.holdoff");
+}
 
 void VQwHardwareChannel::SetSingleEventCuts(Double_t min, Double_t max)
 {

--- a/Parity/src/QwEventRing.cc
+++ b/Parity/src/QwEventRing.cc
@@ -37,6 +37,10 @@ void QwEventRing::DefineOptions(QwOptions &options)
       po::value<int>()->default_value(5),
       "QwEventRing: burp precut");
 
+  options.AddOptions()("burp.holdoff",
+      po::value<int>()->default_value(10),
+      "QwEventRing: burp holdoff");
+
   options.AddOptions()("ring.stability_cut",
       po::value<double>()->default_value(1),
       "QwEventRing: Stability ON/OFF");

--- a/Parity/src/QwEventRing.cc
+++ b/Parity/src/QwEventRing.cc
@@ -65,6 +65,24 @@ void QwEventRing::ProcessOptions(QwOptions &options)
   if (gQwOptions.HasValue("burp.precut"))
     fBurpPrecut=gQwOptions.GetValue<int>("burp.precut");
 
+  int tmpval = fBurpExtent;
+  if (fBurpPrecut>fBurpExtent){
+    QwWarning << "The burp precut ("<<fBurpPrecut
+	      << ") is larger than the burp extent (" 
+	      << fBurpExtent
+	      << "; this may not be what you meant to do."
+	      << QwLog::endl;
+    tmpval =  fBurpPrecut;
+  }
+  tmpval += 2;
+  if (fRING_SIZE<tmpval){
+    QwWarning << "Forcing ring size to be " << tmpval
+	      << " to accomodate a burp extent of " << fBurpExtent
+	      << " and a burp precut of " << fBurpPrecut
+	      << "; it had been " << fRING_SIZE << "." << QwLog::endl;
+    fRING_SIZE = tmpval;
+  }
+
   if (gQwOptions.HasValue("ring.stability_cut"))
     stability=gQwOptions.GetValue<double>("ring.stability_cut");
 


### PR DESCRIPTION
This activates another command-line option to set the holdoff period for the burp cuts.  In this version, all burp cuts have the same number of events cut before the failure (precut) and the same number cut cut after the failure (holdoff).