### PR TITLE
new eventcut mapfiles for respin

### DIFF
--- a/Parity/prminput/prexCH_beamline_eventcuts.2948-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.2948-.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,45 +23,34 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability percentage
- bcm, bcm_an_ds3,		10,	1e6,	g,	0.8
- bpmstripline,	bpm12,	effectivecharge, 0, 1.8e5, g, 500
- bpmstripline, bpm4a, ym, 10000, 50000, l
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
+
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_an_ds3,	35,	1e6,	g,	1
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	ym,	10000,	50000,	l
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000

--- a/Parity/prminput/prexCH_beamline_eventcuts.2948-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.2948-.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds3,	35,	1e6,	g,	1
+ bcm,	bcm_an_ds,	35,	1e6,	g,	1
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3139.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3139.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds3,	35,	1e6,	g,	1
+ bcm,	bcm_an_ds,	35,	1e6,	g,	1
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3139.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3139.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,45 +23,34 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability percentage
- bcm, bcm_an_ds3,		45,	1e6,	g,	0.8
- bpmstripline,	bpm12,	effectivecharge, 0, 1.8e5, g, 500
- bpmstripline, bpm4a, ym, 10000, 50000, l
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
+
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_an_ds3,	35,	1e6,	g,	1
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	ym,	10000,	50000,	l
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000

--- a/Parity/prminput/prexCH_beamline_eventcuts.3140.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3140.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,56 +23,41 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability percentage
- bcm, bcm_an_ds3,		12,	1e6,	g,	0.15
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 10000, 50000, l
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
+
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_an_ds3,	35,	1e6,	g,	1
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000

--- a/Parity/prminput/prexCH_beamline_eventcuts.3140.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3140.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds3,	35,	1e6,	g,	1
+ bcm,	bcm_an_ds,	35,	1e6,	g,	1
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3146.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3146.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds3,	45,	1e6,	g,	1.2
+ bcm,	bcm_an_ds,	45,	1e6,	g,	1.2
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3146.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3146.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,56 +23,41 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability percentage
- bcm, bcm_an_ds3,		12,	1e6,	g,	0.1
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 10000, 50000, l
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
+
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_an_ds3,	45,	1e6,	g,	1.2
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000

--- a/Parity/prminput/prexCH_beamline_eventcuts.3146.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3146.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds,	45,	1e6,	g,	1.2
+ bcm,	bcm_an_ds,	35,	1e6,	g,	1.2
 
 
 
@@ -61,3 +61,15 @@ EVENTCUTS = 3
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm14,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm14,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm14,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm14,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm8,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm8,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm8,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm8,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.35,	0.35
+ bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.35,	0.35
+ bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.35,	0.35
+ bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.35,	0.35

--- a/Parity/prminput/prexCH_beamline_eventcuts.3289-3292.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3289-3292.map
@@ -1,0 +1,75 @@
+!This file contains beamline event cut properties
+!*********************************************************************************************
+!Global switch to turn ON and OFF eventcut check
+!Available settings
+!***************************************************
+!To turn OFF all checks
+!EVENTCUTS = 0 
+
+!***************************************************
+!To turn OFF event cuts and perform only HW checks
+!EVENTCUTS = 1
+
+!***************************************************
+!To turn ON both event cuts and HW checks
+! EVENTCUTS = 2
+
+!***************************************************
+!To turn do both event cuts and HW checks and only flag event cut failed events
+EVENTCUTS = 3
+
+!IMPORTANT
+!---------
+!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
+!Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
+
+!Comments
+!--------
+!Devices that are not in the list are not subjected event cut checks
+!All devices  will be tested for HW checks.
+
+
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_an_ds,	35,	1e6,	g,	1.2
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm14,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm14,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm14,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm14,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm8,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm8,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm8,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm8,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.35,	0.35
+ bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.35,	0.35
+ bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.35,	0.35
+ bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.35,	0.35

--- a/Parity/prminput/prexCH_beamline_eventcuts.3403-3404.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3403-3404.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds3,	35,	1e6,	g,	1
+ bcm,	bcm_an_ds,	35,	1e6,	g,	1
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3403-3404.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3403-3404.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,69 +23,46 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS, burplevel
-
-!Run 3404 has a brief > +0.5mm x position
- bpmstripline, bpm4e, absx, -1, 1, g
-
- bcm, bcm_an_ds3,		35,	1e6,	g,	0.8
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, yp, 1000, 55000, g, 0, 1000
-! bpmstripline,	bpm11,	effectivecharge, 0, 1.8e5, g, 0
- !bpmstripline,	bpm4e,	effectivecharge, 0, 1.8e5, g, 0
- !bpmstripline,	bpm4a,	effectivecharge, 0, 1.8e5, g, 0
- !bpmstripline,	bpm4ec,	effectivecharge, 0, 1.8e5, g, 0
- !bpmstripline,	bpm4ac,	effectivecharge, 0, 1.8e5, g, 0
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
 
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_an_ds3,	35,	1e6,	g,	1
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	absx,	-1,	1,	g

--- a/Parity/prminput/prexCH_beamline_eventcuts.3420.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3420.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,59 +23,45 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability percentage
- bcm, bcm_an_ds3,		35,	1e6,	g,	0.8
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, yp, 1000, 55000, g, 0, 1000
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
+
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_an_ds3,	35,	1e6,	g,	1
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000

--- a/Parity/prminput/prexCH_beamline_eventcuts.3420.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3420.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds3,	35,	1e6,	g,	1
+ bcm,	bcm_an_ds,	35,	1e6,	g,	1
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3425-3428.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3425-3428.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+ bcm,	bcm_an_ds3,	55,	1e6,	g,	1.4
 
 
 
@@ -49,20 +49,8 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	10000,	50000,	l
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm4a,	absy,	1.5,	2.5,	g,	0,	0

--- a/Parity/prminput/prexCH_beamline_eventcuts.3425-3428.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3425-3428.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds3,	55,	1e6,	g,	1.4
+ bcm,	bcm_an_ds,	55,	1e6,	g,	1.4
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3450-3452.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3450-3452.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,51 +23,46 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS
- bcm, bcm_an_ds3,		35,	1e6,	g,	0.8
- bpmstripline,	bpm12,	effectivecharge, 0, 1.8e5, g, 0
- bpmstripline,	bpm4e,	effectivecharge, 0, 1.8e5, g, 0
- bpmstripline,	bpm4a,	effectivecharge, 0, 1.8e5, g, 0
- bpmstripline, bpm4e, absx, -10, 10, g, 0.16, 0
- bpmstripline, bpm4a, absx, -10, 10, g, 0.02, 0
- bpmstripline, bpm4e, absy, -10, 10, g, 0.02, 0
- bpmstripline, bpm4a, absy, -10, 10, g, 0.03, 0
- bpmstripline, bpm12, absx, -10, 10, g, 0.05, 0
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
+
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_an_ds3,	35,	1e6,	g,	1
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	absx,	-10,	10,	g,	0.02,	0
+ bpmstripline,	bpm4a,	absy,	-10,	10,	g,	0.03,	0
+ bpmstripline,	bpm4e,	absx,	-10,	10,	g,	0.16,	0
+ bpmstripline,	bpm4e,	absy,	-10,	10,	g,	0.02,	0
+ bpmstripline,	bpm12,	absx,	-10,	10,	g,	0.05,	0

--- a/Parity/prminput/prexCH_beamline_eventcuts.3450-3452.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3450-3452.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds3,	35,	1e6,	g,	1
+ bcm,	bcm_an_ds,	35,	1e6,	g,	1
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3453-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3453-.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,59 +23,45 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS
- bcm, bcm_an_ds,		35,	1e6,	g,	0.8
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, yp, 1000, 55000, g, 0, 1000
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability RMS
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
+
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_an_ds,	35,	1e6,	g,	1
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000

--- a/Parity/prminput/prexCH_beamline_eventcuts.3455.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3455.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,51 +23,46 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS
- bcm, bcm_an_ds3,		35,	1e6,	g,	0.8
- bpmstripline,	bpm12,	effectivecharge, 0, 1.8e5, g, 0
- bpmstripline,	bpm4e,	effectivecharge, 0, 1.8e5, g, 0
- bpmstripline,	bpm4a,	effectivecharge, 0, 1.8e5, g, 0
- bpmstripline, bpm4e, absx, -10, 10, g, 0.16, 0
- bpmstripline, bpm4a, absx, -10, 10, g, 0.02, 0
- bpmstripline, bpm4e, absy, -10, 10, g, 0.02, 0
- bpmstripline, bpm4a, absy, -10, 10, g, 0.03, 0
- bpmstripline, bpm12, absx, -10, 10, g, 0.05, 0
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
+
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_an_ds3,	35,	1e6,	g,	1
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	absx,	-10,	10,	g,	0.02,	0
+ bpmstripline,	bpm4a,	absy,	-10,	10,	g,	0.03,	0
+ bpmstripline,	bpm4e,	absx,	-10,	10,	g,	0.16,	0
+ bpmstripline,	bpm4e,	absy,	-10,	10,	g,	0.02,	0
+ bpmstripline,	bpm12,	absx,	-10,	10,	g,	0.05,	0

--- a/Parity/prminput/prexCH_beamline_eventcuts.3455.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3455.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds3,	35,	1e6,	g,	1
+ bcm,	bcm_an_ds,	35,	1e6,	g,	1
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3489.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3489.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds3,	35,	1e6,	g,	1
+ bcm,	bcm_an_ds,	35,	1e6,	g,	1
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3489.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3489.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,46 +23,41 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS
- bcm, bcm_an_ds3,		35,	1e6,	g,	0.8
- bpmstripline,	bpm12,	effectivecharge, 0, 1.8e5, g, 1500
- bpmstripline,	bpm4e,	effectivecharge, 0, 1.8e5, g, 1500
- bpmstripline,	bpm4a,	effectivecharge, 0, 1.8e5, g, 1500
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability RMS
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
+
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_an_ds3,	35,	1e6,	g,	1
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000

--- a/Parity/prminput/prexCH_beamline_eventcuts.3524.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3524.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,51 +23,46 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS
- bcm, bcm_an_ds3,		35,	1e6,	g,	0.8
- bpmstripline,	bpm12,	effectivecharge, 0, 1.8e5, g, 0
- bpmstripline,	bpm4e,	effectivecharge, 0, 1.8e5, g, 0
- bpmstripline,	bpm4a,	effectivecharge, 0, 1.8e5, g, 0
- bpmstripline, bpm4e, absx, -10, 10, g, 0.16, 0
- bpmstripline, bpm4a, absx, -10, 10, g, 0.02, 0
- bpmstripline, bpm4e, absy, -10, 10, g, 0.02, 0
- bpmstripline, bpm4a, absy, -10, 10, g, 0.03, 0
- bpmstripline, bpm12, absx, -10, 10, g, 0.05, 0
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
+
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_an_ds3,	35,	1e6,	g,	1
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	absx,	-10,	10,	g,	0.02,	0
+ bpmstripline,	bpm4a,	absy,	-10,	10,	g,	0.03,	0
+ bpmstripline,	bpm4e,	absx,	-10,	10,	g,	0.16,	0
+ bpmstripline,	bpm4e,	absy,	-10,	10,	g,	0.02,	0
+ bpmstripline,	bpm12,	absx,	-10,	10,	g,	0.05,	0

--- a/Parity/prminput/prexCH_beamline_eventcuts.3524.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3524.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds3,	35,	1e6,	g,	1
+ bcm,	bcm_an_ds,	35,	1e6,	g,	1
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3540.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3540.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,51 +23,46 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS
- bcm, bcm_an_ds3,		35,	1e6,	g,	0.8
- bpmstripline,	bpm12,	effectivecharge, 0, 1.8e5, g, 0
- bpmstripline,	bpm4e,	effectivecharge, 0, 1.8e5, g, 0
- bpmstripline,	bpm4a,	effectivecharge, 0, 1.8e5, g, 0
- bpmstripline, bpm4e, absx, -10, 10, g, 0.16, 0
- bpmstripline, bpm4a, absx, -10, 10, g, 0.02, 0
- bpmstripline, bpm4e, absy, -10, 10, g, 0.02, 0
- bpmstripline, bpm4a, absy, -10, 10, g, 0.03, 0
- bpmstripline, bpm12, absx, -10, 10, g, 0.05, 0
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
+
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_an_ds3,	35,	1e6,	g,	1
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	absx,	-10,	10,	g,	0.02,	0
+ bpmstripline,	bpm4a,	absy,	-10,	10,	g,	0.03,	0
+ bpmstripline,	bpm4e,	absx,	-10,	10,	g,	0.16,	0
+ bpmstripline,	bpm4e,	absy,	-10,	10,	g,	0.02,	0
+ bpmstripline,	bpm12,	absx,	-10,	10,	g,	0.05,	0

--- a/Parity/prminput/prexCH_beamline_eventcuts.3540.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3540.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds3,	35,	1e6,	g,	1
+ bcm,	bcm_an_ds,	35,	1e6,	g,	1
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3548.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3548.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,63 +23,46 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS
-
-! Adding a cut on yield to kill the last bunch of events
- bpmstripline, bpm4e, absy, -1, 1.25, g
-
- bcm, bcm_an_ds,		35,	1e6,	g,	0.8
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, yp, 1000, 55000, g, 0, 1000
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability RMS
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
+
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_an_ds,	35,	1e6,	g,	1
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	absy,	-1,	1.25,	g

--- a/Parity/prminput/prexCH_beamline_eventcuts.3566-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3566-.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,61 +23,45 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS
-! 50 uA beam, BPM tracking sane positions and non-saturation, global promotion of device error codes, BPM 4aYM had a few runs with strange wire response due to poor BNC connection
- bcm, bcm_an_ds,		35,	1e6,	g,	0.8
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, yp, 1000, 55000, g, 0, 1000
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
 
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_an_ds,	35,	1e6,	g,	1
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000

--- a/Parity/prminput/prexCH_beamline_eventcuts.3595-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3595-.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,66 +23,45 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS
-! 70 uA running BCM, BPM tracking non-saturation, global promotion of device error codes, BPM 4aYM had a few runs with strange wire response due to poor BNC connection
-! So far stability cut on bcm_an_ds was 0.8. As we decided in WAC meeting 07/24/2019, we make the cut 1.4 for 70uA and 1 for 50uA running. i.e 2% stability cut.
-! Updating temporarily the current limit to include 50 uA until 70 uA stable running achieved - also changing to DG ds BCM to mitigate noise
- !bcm, bcm_an_ds,		35,	1e6,	g,	1.4
- bcm, bcm_dg_ds,		35,	1e6,	g,	1.4
-! Adding the upstream BCM too, mostly for verification that it has no hardware errors and that it is also seeing the same beam
- !bcm, bcm_an_us,		5,	1e6,	g, 0
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, yp, 1000, 55000, g, 0, 1000
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
 
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000

--- a/Parity/prminput/prexCH_beamline_eventcuts.3622-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3622-.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,72 +23,45 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS, burplevel
-! 70 uA running BCM, BPM tracking non-saturation, global promotion of device error codes, BPM 4aYM had a few runs with strange wire response due to poor BNC connection
-! So far stability cut on bcm_an_ds was 0.8. As we decided in WAC meeting 07/24/2019, we make the cut 1.4 for 70uA and 1 for 50uA running. i.e 2% stability cut.
-! Updating temporarily the current limit to include 50 uA until 70 uA stable running achieved - also changing to DG ds BCM to mitigate noise
- !bcm, bcm_an_ds,		35,	1e6,	g,	1.4
- bcm, bcm_dg_ds,		35,	1e6,	g,	1.4
-! Adding the upstream BCM too, mostly for verification that it has no hardware errors and that it is also seeing the same beam
- !bcm, bcm_an_us,		5,	1e6,	g, 0
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, yp, 1000, 55000, g, 0, 1000
-! bpmstripline,	bpm11,	effectivecharge, 0, 1.8e5, g, 0
- !bpmstripline,	bpm4e,	effectivecharge, 0, 1.8e5, g, 0
- !bpmstripline,	bpm4a,	effectivecharge, 0, 1.8e5, g, 0
- !bpmstripline,	bpm4ec,	effectivecharge, 0, 1.8e5, g, 0
- !bpmstripline,	bpm4ac,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline, bpm4a, ym, 10000, 50000, l
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
 
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000

--- a/Parity/prminput/prexCH_beamline_eventcuts.3633-3636.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3633-3636.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+ bcm,	bcm_dg_ds,	45,	1e6,	g,	1.2
 
 
 
@@ -65,4 +65,3 @@ EVENTCUTS = 3
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm4a,	absy,	1.5,	2.5,	g,	0,	0

--- a/Parity/prminput/prexCH_beamline_eventcuts.3821.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3821.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+ bcm,	bcm_dg_ds,	45,	1e6,	g,	1.2
 
 
 
@@ -65,4 +65,3 @@ EVENTCUTS = 3
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm4a,	absy,	1.5,	2.5,	g,	0,	0

--- a/Parity/prminput/prexCH_beamline_eventcuts.3912-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3912-.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,78 +23,49 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS, burplevel
-! 70 uA running BCM, BPM tracking non-saturation, global promotion of device error codes, BPM 4aYM had a few runs with strange wire response due to poor BNC connection
-! So far stability cut on bcm_an_ds was 0.8. As we decided in WAC meeting 07/24/2019, we make the cut 1.4 for 70uA and 1 for 50uA running. i.e 2% stability cut.
-! Updating temporarily the current limit to include 50 uA until 70 uA stable running achieved - also changing to DG ds BCM to mitigate noise
- bcm, bcm_an_us,		35,	1e6,	g,	1.4
- !bcm, bcm_dg_ds,		35,	1e6,	g,	1.4
-! Adding the upstream BCM too, mostly for verification that it has no hardware errors and that it is also seeing the same beam
- !bcm, bcm_an_us,		5,	1e6,	g, 0
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, yp, 1000, 55000, g, 0, 1000
-! bpmstripline,	bpm11,	effectivecharge, 0, 1.8e5, g, 0
- !bpmstripline,	bpm4e,	effectivecharge, 0, 1.8e5, g, 0
- !bpmstripline,	bpm4a,	effectivecharge, 0, 1.8e5, g, 0
- !bpmstripline,	bpm4ec,	effectivecharge, 0, 1.8e5, g, 0
- !bpmstripline,	bpm4ac,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline, bpm4a, ym, 10000, 50000, l
-
-bpmstripline, bpm4a, absx, -200, 200, g, 0, 0.2
-bpmstripline, bpm4a, absy, -200, 200, g, 0, 0.2
-bpmstripline, bpm4e, absx, -200, 200, g, 0, 0.2
-bpmstripline, bpm4e, absy, -200, 200, g, 0, 0.2
-
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
 
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_an_us,	55,	1e6,	g,	1.4
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0,	0.2
+ bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0,	0.2
+ bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0,	0.2
+ bpmstripline,	bpm4e,	absy,	-200,	200,	g,	0,	0.2

--- a/Parity/prminput/prexCH_beamline_eventcuts.4169.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4169.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,78 +23,49 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS, burplevel
-! 70 uA running BCM, BPM tracking non-saturation, global promotion of device error codes, BPM 4aYM had a few runs with strange wire response due to poor BNC connection
-! So far stability cut on bcm_an_ds was 0.8. As we decided in WAC meeting 07/24/2019, we make the cut 1.4 for 70uA and 1 for 50uA running. i.e 2% stability cut.
-! Updating temporarily the current limit to include 50 uA until 70 uA stable running achieved - also changing to DG ds BCM to mitigate noise
- bcm, bcm_an_us,		35,	1e6,	g,	1.4
- !bcm, bcm_dg_ds,		35,	1e6,	g,	1.4
-! Adding the upstream BCM too, mostly for verification that it has no hardware errors and that it is also seeing the same beam
- !bcm, bcm_an_us,		5,	1e6,	g, 0
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, yp, 1000, 55000, g, 0, 1000
-! bpmstripline,	bpm11,	effectivecharge, 0, 1.8e5, g, 0
- !bpmstripline,	bpm4e,	effectivecharge, 0, 1.8e5, g, 0
- !bpmstripline,	bpm4a,	effectivecharge, 0, 1.8e5, g, 0
- !bpmstripline,	bpm4ec,	effectivecharge, 0, 1.8e5, g, 0
- !bpmstripline,	bpm4ac,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline, bpm4a, ym, 10000, 50000, l
-
-bpmstripline, bpm4a, absx, -200, 200, g, 0, 0.2
-bpmstripline, bpm4a, absy, -200, 200, g, 0, 0.2
-bpmstripline, bpm4e, absx, -200, 0.5, g, 0, 0.2
-bpmstripline, bpm4e, absy, -200, 200, g, 0, 0.2
-
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
 
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_an_us,	55,	1e6,	g,	1.4
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0,	0.2
+ bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0,	0.2
+ bpmstripline,	bpm4e,	absx,	-200,	0.5,	g,	0,	0.2
+ bpmstripline,	bpm4e,	absy,	-200,	200,	g,	0,	0.2

--- a/Parity/prminput/prexCH_beamline_eventcuts.4224.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4224.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,78 +23,49 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS, burplevel
-! 70 uA running BCM, BPM tracking non-saturation, global promotion of device error codes, BPM 4aYM had a few runs with strange wire response due to poor BNC connection
-! So far stability cut on bcm_an_ds was 0.8. As we decided in WAC meeting 07/24/2019, we make the cut 1.4 for 70uA and 1 for 50uA running. i.e 2% stability cut.
-! Updating temporarily the current limit to include 50 uA until 70 uA stable running achieved - also changing to DG ds BCM to mitigate noise
- bcm, bcm_an_us,		35,	1e6,	g,	1.4
- !bcm, bcm_dg_ds,		35,	1e6,	g,	1.4
-! Adding the upstream BCM too, mostly for verification that it has no hardware errors and that it is also seeing the same beam
- !bcm, bcm_an_us,		5,	1e6,	g, 0
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, yp, 1000, 55000, g, 0, 1000
-! bpmstripline,	bpm11,	effectivecharge, 0, 1.8e5, g, 0
- !bpmstripline,	bpm4e,	effectivecharge, 0, 1.8e5, g, 0
- !bpmstripline,	bpm4a,	effectivecharge, 0, 1.8e5, g, 0
- !bpmstripline,	bpm4ec,	effectivecharge, 0, 1.8e5, g, 0
- !bpmstripline,	bpm4ac,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline, bpm4a, ym, 10000, 50000, l
-
-bpmstripline, bpm4a, absx, -200, 200, g, 0, 0.2
-bpmstripline, bpm4a, absy, -200, 200, g, 0, 0.2
-bpmstripline, bpm4e, absx, -0.2, 0.7, g, 0, 0.2
-bpmstripline, bpm4e, absy, -200, 200, g, 0, 0.2
-
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
 
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_an_us,	55,	1e6,	g,	1.4
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0,	0.2
+ bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0,	0.2
+ bpmstripline,	bpm4e,	absx,	-0.2,	0.7,	g,	0,	0.2
+ bpmstripline,	bpm4e,	absy,	-200,	200,	g,	0,	0.2

--- a/Parity/prminput/prexCH_beamline_eventcuts.4257-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4257-.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,73 +23,49 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS, burplevel
-! 70 uA running BCM, BPM tracking non-saturation, global promotion of device error codes
- bcm, bcm_an_us,		5,	1e6,	l 
- bcm, bcm_dg_ds,		35,	1e6,	g,	1.4
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, yp, 1000, 55000, g, 0, 1000
-! bpmstripline,	bpm11,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4e,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4a,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ec,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ac,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline, bpm4a, ym, 10000, 50000, l
-
-bpmstripline, bpm4a, absx, -200, 200, g, 0, 0.2
-bpmstripline, bpm4a, absy, -200, 200, g, 0, 0.2
-bpmstripline, bpm4e, absx, -200, 200, g, 0, 0.2
-bpmstripline, bpm4e, absy, -200, 200, g, 0, 0.2
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
 
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0,	0.2
+ bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0,	0.2
+ bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0,	0.2
+ bpmstripline,	bpm4e,	absy,	-200,	200,	g,	0,	0.2

--- a/Parity/prminput/prexCH_beamline_eventcuts.4396.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4396.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,73 +23,49 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS, burplevel
-! 70 uA running BCM, BPM tracking non-saturation, global promotion of device error codes
- bcm, bcm_an_us,		5,	1e6,	l 
- bcm, bcm_dg_ds,		60,	1e6,	g,	1.4
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, yp, 1000, 55000, g, 0, 1000
-! bpmstripline,	bpm11,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4e,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4a,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ec,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ac,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline, bpm4a, ym, 10000, 50000, l
-
-bpmstripline, bpm4a, absx, -200, 200, g, 0, 0.2
-bpmstripline, bpm4a, absy, -200, 200, g, 0, 0.2
-bpmstripline, bpm4e, absx, -200, 200, g, 0, 0.2
-bpmstripline, bpm4e, absy, -200, 200, g, 0, 0.2
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
 
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0,	0.2
+ bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0,	0.2
+ bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0,	0.2
+ bpmstripline,	bpm4e,	absy,	-200,	200,	g,	0,	0.2

--- a/Parity/prminput/prexCH_beamline_eventcuts.4439-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4439-.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,73 +23,49 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS, burplevel
-! 70 uA running BCM, BPM tracking non-saturation, global promotion of device error codes
- bcm, bcm_an_us,		5,	1e6,	l 
- bcm, bcm_dg_ds,		35,	1e6,	g,	1.4
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, yp, 1000, 55000, g, 0, 1000
-! bpmstripline,	bpm11,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4e,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4a,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ec,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ac,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline, bpm4a, ym, 10000, 50000, l
-
-bpmstripline, bpm4a, absx, -200, 200, g, 0, 0.35
-bpmstripline, bpm4a, absy, -200, 200, g, 0, 0.35
-bpmstripline, bpm4e, absx, -200, 200, g, 0, 0.35
-bpmstripline, bpm4e, absy, -200, 200, g, 0, 0.35
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
 
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0,	0.35
+ bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0,	0.35
+ bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0,	0.35
+ bpmstripline,	bpm4e,	absy,	-200,	200,	g,	0,	0.35

--- a/Parity/prminput/prexCH_beamline_eventcuts.4472.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4472.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,73 +23,49 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS, burplevel
-! 70 uA running BCM, BPM tracking non-saturation, global promotion of device error codes
- bcm, bcm_an_us,		5,	1e6,	l 
- bcm, bcm_dg_ds,		35,	1e6,	g,	1.4
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, yp, 1000, 55000, g, 0, 1000
-! bpmstripline,	bpm11,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4e,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4a,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ec,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ac,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline, bpm4a, ym, 10000, 50000, l
-
-bpmstripline, bpm4a, absx, -200, 200, g, 0, 0.2
-bpmstripline, bpm4a, absy, -200, 200, g, 0, 0.2
-bpmstripline, bpm4e, absx, -200, 200, g, 0, 0.2
-bpmstripline, bpm4e, absy, -200, 200, g, 0, 0.2
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
 
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0,	0.2
+ bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0,	0.2
+ bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0,	0.2
+ bpmstripline,	bpm4e,	absy,	-200,	200,	g,	0,	0.2

--- a/Parity/prminput/prexCH_beamline_eventcuts.4481-4482.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4481-4482.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,73 +23,49 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS, burplevel
-! 70 uA running BCM, BPM tracking non-saturation, global promotion of device error codes
- bcm, bcm_an_us,		5,	1e6,	l 
- bcm, bcm_dg_ds,		35,	1e6,	g,	1.4
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, yp, 1000, 55000, g, 0, 1000
-! bpmstripline,	bpm11,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4e,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4a,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ec,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ac,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline, bpm4a, ym, 10000, 50000, l
-
-bpmstripline, bpm4a, absx, -200, 200, g, 0.35, 0.2
-bpmstripline, bpm4a, absy, -200, 200, g, 0.35, 0.2
-bpmstripline, bpm4e, absx, -200, 200, g, 0.35, 0.2
-bpmstripline, bpm4e, absy, -200, 200, g, 0.35, 0.2
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
 
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.35,	0.2
+ bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.35,	0.2
+ bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.35,	0.2
+ bpmstripline,	bpm4e,	absy,	-200,	200,	g,	0.35,	0.2

--- a/Parity/prminput/prexCH_beamline_eventcuts.4481.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4481.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,73 +23,49 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS, burplevel
-! 70 uA running BCM, BPM tracking non-saturation, global promotion of device error codes
- bcm, bcm_an_us,		5,	1e6,	l 
- bcm, bcm_dg_ds,		35,	1e6,	g,	1.4
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, yp, 1000, 55000, g, 0, 1000
-! bpmstripline,	bpm11,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4e,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4a,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ec,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ac,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline, bpm4a, ym, 10000, 50000, l
-
-bpmstripline, bpm4a, absx, -200, 200, g, 0, 0.35
-bpmstripline, bpm4a, absy, -200, 200, g, 0, 0.35
-bpmstripline, bpm4e, absx, -200, 200, g, 0, 0.35
-bpmstripline, bpm4e, absy, -200, 200, g, 0, 0.35
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
 
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0,	0.35
+ bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0,	0.35
+ bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0,	0.35
+ bpmstripline,	bpm4e,	absy,	-200,	200,	g,	0,	0.35

--- a/Parity/prminput/prexCH_beamline_eventcuts.4491.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4491.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,73 +23,49 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS, burplevel
-! 70 uA running BCM, BPM tracking non-saturation, global promotion of device error codes
- bcm, bcm_an_us,		5,	1e6,	l 
- bcm, bcm_dg_ds,		35,	1e6,	g,	1.4
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, yp, 1000, 55000, g, 0, 1000
-! bpmstripline,	bpm11,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4e,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4a,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ec,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ac,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline, bpm4a, ym, 10000, 50000, l
-
-bpmstripline, bpm4a, absx, -200, 200, g, 0.3, 0.3
-bpmstripline, bpm4a, absy, -200, 200, g, 0.3, 0.3
-bpmstripline, bpm4e, absx, -200, 200, g, 0.3, 0.3
-bpmstripline, bpm4e, absy, -200, 200, g, 0.3, 0.3
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
 
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.3,	0.3
+ bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.3,	0.3
+ bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.3,	0.3
+ bpmstripline,	bpm4e,	absy,	-200,	200,	g,	0.3,	0.3

--- a/Parity/prminput/prexCH_beamline_eventcuts.4498.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4498.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,73 +23,49 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS, burplevel
-! 70 uA running BCM, BPM tracking non-saturation, global promotion of device error codes
- bcm, bcm_an_us,		5,	1e6,	l 
- bcm, bcm_dg_ds,		35,	1e6,	g,	1.4
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, yp, 1000, 55000, g, 0, 1000
-! bpmstripline,	bpm11,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4e,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4a,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ec,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ac,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline, bpm4a, ym, 10000, 50000, l
-
-bpmstripline, bpm4a, absx, -200, 200, g, 0.5, 0.35
-bpmstripline, bpm4a, absy, -200, 200, g, 0.5, 0.35
-bpmstripline, bpm4e, absx, -0.2, 0.8, g, 0.5, 0.35
-bpmstripline, bpm4e, absy, -200, 200, g, 0.5, 0.35
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
 
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.5,	0.35
+ bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.5,	0.35
+ bpmstripline,	bpm4e,	absx,	-0.2,	0.8,	g,	0.5,	0.35
+ bpmstripline,	bpm4e,	absy,	-200,	200,	g,	0.5,	0.35

--- a/Parity/prminput/prexCH_beamline_eventcuts.4503.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4503.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,73 +23,49 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS, burplevel
-! 70 uA running BCM, BPM tracking non-saturation, global promotion of device error codes
- bcm, bcm_an_us,		5,	1e6,	l 
- bcm, bcm_dg_ds,		35,	1e6,	g,	1.4
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, yp, 1000, 55000, g, 0, 1000
-! bpmstripline,	bpm11,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4e,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4a,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ec,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ac,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline, bpm4a, ym, 10000, 50000, l
-
-bpmstripline, bpm4a, absx, -200, 200, g, 0.3, 0.2
-bpmstripline, bpm4a, absy, -200, 200, g, 0.3, 0.2
-bpmstripline, bpm4e, absx, -200, 200, g, 0.3, 0.2
-bpmstripline, bpm4e, absy, -200, 200, g, 0.3, 0.2
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
 
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.3,	0.2
+ bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.3,	0.2
+ bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.3,	0.2
+ bpmstripline,	bpm4e,	absy,	-200,	200,	g,	0.3,	0.2

--- a/Parity/prminput/prexCH_beamline_eventcuts.4512.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4512.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,73 +23,49 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS, burplevel
-! 70 uA running BCM, BPM tracking non-saturation, global promotion of device error codes
- bcm, bcm_an_us,		5,	1e6,	l 
- bcm, bcm_dg_ds,		35,	1e6,	g,	1.4
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, yp, 1000, 55000, g, 0, 1000
-! bpmstripline,	bpm11,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4e,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4a,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ec,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ac,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline, bpm4a, ym, 10000, 50000, l
-
-bpmstripline, bpm4a, absx, -200, 200, g, 0.35, 0.35
-bpmstripline, bpm4a, absy, -200, 200, g, 0.35, 0.35
-bpmstripline, bpm4e, absx, -200, 200, g, 0.35, 0.35
-bpmstripline, bpm4e, absy, -200, 200, g, 0.35, 0.35
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
 
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.35,	0.35
+ bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.35,	0.35
+ bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.35,	0.35
+ bpmstripline,	bpm4e,	absy,	-200,	200,	g,	0.35,	0.35

--- a/Parity/prminput/prexCH_beamline_eventcuts.4514.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4514.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,73 +23,49 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS, burplevel
-! 70 uA running BCM, BPM tracking non-saturation, global promotion of device error codes
- bcm, bcm_an_us,		5,	1e6,	l 
- bcm, bcm_dg_ds,		35,	1e6,	g,	1.4
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, yp, 1000, 55000, g, 0, 1000
-! bpmstripline,	bpm11,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4e,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4a,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ec,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ac,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline, bpm4a, ym, 10000, 50000, l
-
-bpmstripline, bpm4a, absx, -200, 200, g, 0.35, 0.35
-bpmstripline, bpm4a, absy, -200, 200, g, 0.35, 0.35
-bpmstripline, bpm4e, absx, -200, 200, g, 0.35, 0.35
-bpmstripline, bpm4e, absy, -200, 200, g, 0.35, 0.35
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
 
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.35,	0.35
+ bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.35,	0.35
+ bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.35,	0.35
+ bpmstripline,	bpm4e,	absy,	-200,	200,	g,	0.35,	0.35

--- a/Parity/prminput/prexCH_beamline_eventcuts.4529-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4529-.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,73 +23,49 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS, burplevel
-! 70 uA running BCM, BPM tracking non-saturation, global promotion of device error codes
- bcm, bcm_an_us,		5,	1e6,	l 
- bcm, bcm_dg_ds,		35,	1e6,	g,	1.4
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, yp, 1000, 55000, g, 0, 1000
-! bpmstripline,	bpm11,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4e,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4a,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ec,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ac,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline, bpm4a, ym, 10000, 50000, l
-
-bpmstripline, bpm4a, absx, -200, 200, g, 0.35, 0.35
-bpmstripline, bpm4a, absy, -200, 200, g, 0.35, 0.35
-bpmstripline, bpm4e, absx, -200, 200, g, 0.35, 0.35
-bpmstripline, bpm4e, absy, -200, 200, g, 0.35, 0.35
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
 
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.35,	0.35
+ bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.35,	0.35
+ bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.35,	0.35
+ bpmstripline,	bpm4e,	absy,	-200,	200,	g,	0.35,	0.35

--- a/Parity/prminput/prexCH_beamline_eventcuts.4532.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4532.map
@@ -1,4 +1,3 @@
-
 !This file contains beamline event cut properties
 !*********************************************************************************************
 !Global switch to turn ON and OFF eventcut check
@@ -24,73 +23,49 @@ EVENTCUTS = 3
 !Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
 !Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
 
-!***************************************************
-!for bcm devices
-!device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS, burplevel
-! 70 uA running BCM, BPM tracking non-saturation, global promotion of device error codes
- bcm, bcm_an_us,		5,	1e6,	l 
- bcm, bcm_dg_ds,		35,	1e6,	g,	1.4
- bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4a, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm4e, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm12, yp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xm, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, xp, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, ym, 1000, 55000, g, 0, 1000
- bpmstripline, bpm11, yp, 1000, 55000, g, 0, 1000
-! bpmstripline,	bpm11,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4e,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4a,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ec,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline,	bpm4ac,	effectivecharge, 0, 1.8e5, g, 0
-! bpmstripline, bpm4a, ym, 10000, 50000, l
-
-bpmstripline, bpm4a, absx, -200, 200, g, 0.25, 0.35
-bpmstripline, bpm4a, absy, -200, 200, g, 0.25, 0.35
-bpmstripline, bpm4e, absx, -200, 200, g, 0.25, 0.35
-bpmstripline, bpm4e, absy, -200, 200, g, 0.25, 0.35
-
-!for parity mock data run 1000 9.98608e+06
-!bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 
-
- 
-!bcm, qwk_batery6,  	0,	0, 1, 0 
-!bcm, qwk_batery7, 	95.57778e+9,	95.5788e+9, 1, 0 
-!bcm, phasemonitor, 	0,	0, 1, 0
-
-!****************************************************				
-!for bpmstrpline devices
-!device_type, device_name, channel_name, lower limit, upper limit
-!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
-!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
-!So pedestals are applied before appyling the cuts.
-
-!device_type,  device_name, channel_name, lower limit, upper limit, local(l)/global(g), stability percentage
-! the following line is an example
-!bpmstripline, qwk_qpd, relx, 2.67319, 	4.45531
-
-
-
-!This file contains beamline event cut properties
-
-!IMPORTANT
-!---------
-!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
-!Otherwise the routine QwParameterFile::GetNextToken(", ") will extract the entry with the tab character.
-
 !Comments
 !--------
 !Devices that are not in the list are not subjected event cut checks
 !All devices  will be tested for HW checks.
-!
-!For device_type =bcm only upper and lower limit of the calibrated charge on the ADC HW sum. (QwVQWK_Channel::fHardwareBlockSum)
 
 
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.25,	0.35
+ bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.25,	0.35
+ bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.25,	0.35
+ bpmstripline,	bpm4e,	absy,	-200,	200,	g,	0.25,	0.35

--- a/Parity/prminput/prexCH_beamline_eventcuts.4872-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4872-.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+ bcm,	bcm_dg_ds,	70,	1e6,	g,	1.7
 
 
 
@@ -65,4 +65,7 @@ EVENTCUTS = 3
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm4a,	absy,	1.5,	2.5,	g,	0,	0
+ bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.35,	0.35
+ bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.35,	0.35
+ bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.35,	0.35
+ bpmstripline,	bpm4e,	absy,	-200,	200,	g,	0.35,	0.35


### PR DESCRIPTION
* add following new mapfiles:
    * prexCH_beamline_eventcuts.3425-3428.map       70μA -- 55μA
    * prexCH_beamline_eventcuts.3633-3636.map       60μA -- 45μA
    * prexCH_beamline_eventcuts.3821.map            60μA -- 45μA
    * prexCH_beamline_eventcuts.4872-.map           85μA -- 70μA

* for run 3649-3651, they have current of 80 uA, but it should be due to
wrong calibration (the real current should be 70 uA), so the bcm lower limit
for these 3 runs stay to be 55 uA.

* ignore local bcm cut
* change all bcm stability RMS cut to 0.02*current
* change effectivecharge to corresponding wires (xm, xp, ym, yp) cut
* remove repeated bpm 4a ym setting in 3140.map and 3146.map