### PR TITLE
Getting the running sum calculation for the data handlers to work.

### DIFF
--- a/Parity/include/LRBCorrector.h
+++ b/Parity/include/LRBCorrector.h
@@ -40,7 +40,8 @@ class LRBCorrector : public VQwDataHandler, public MQwDataHandlerCloneable<LRBCo
 	fBurstCounter = 0;
       } else {
 	fBurstCounter = fLastCycle-1;
-	QwWarning << "Burst counter, " << burstcounter
+	QwWarning << "LRBCorrector, " << GetName() 
+		  << ": Burst counter, " << burstcounter
 		  << ", is greater than the stored number of sets of slopes.  "
 		  << "Using the last set of slopes (cycle=" << fLastCycle
 		  << ")" << QwLog::endl;

--- a/Parity/include/QwCorrelator.h
+++ b/Parity/include/QwCorrelator.h
@@ -51,6 +51,9 @@ class QwCorrelator : public VQwDataHandler, public MQwDataHandlerCloneable<QwCor
   Int_t ConnectChannels(QwSubsystemArrayParity& asym, QwSubsystemArrayParity& diff);
 
   void ProcessData();
+  void FinishDataHandler(){
+    CalcCorrelations();
+  }
   void CalcCorrelations();
 
   /// \brief Construct the tree branches
@@ -124,6 +127,8 @@ class QwCorrelator : public VQwDataHandler, public MQwDataHandlerCloneable<QwCor
   std::vector<std::vector<TH2D>> fH2dv;
 
   LinRegBevPeb linReg;
+
+  Int_t fCycleCounter;
 
   // Default constructor
   QwCorrelator();

--- a/Parity/include/VQwDataHandler.h
+++ b/Parity/include/VQwDataHandler.h
@@ -42,8 +42,14 @@ class VQwDataHandler:  virtual public VQwDataHandlerCloneable, public MQwPublish
 
     virtual void ParseConfigFile(QwParameterFile& file);
 
-    void SetPointer(QwHelicityPattern *ptr){fHelicityPattern = ptr;};
-    void SetPointer(QwSubsystemArrayParity *ptr){fSubsystemArray = ptr;};
+    void SetPointer(QwHelicityPattern *ptr){
+      fHelicityPattern = ptr;
+      fErrorFlagPtr = ptr->GetEventcutErrorFlagPointer();
+    };
+    void SetPointer(QwSubsystemArrayParity *ptr){
+      fSubsystemArray = ptr;
+      fErrorFlagPtr = ptr->GetEventcutErrorFlagPointer();
+    };
 
     virtual Int_t ConnectChannels(QwSubsystemArrayParity& yield, QwSubsystemArrayParity& asym, QwSubsystemArrayParity& diff){
       return this->ConnectChannels(asym, diff);
@@ -63,9 +69,9 @@ class VQwDataHandler:  virtual public VQwDataHandlerCloneable, public MQwPublish
 
     virtual void UpdateBurstCounter(Short_t burstcounter){fBurstCounter=burstcounter;};
 
-    virtual void FinishDataHandler(){};
-
-    virtual void CalcCorrelations(){};
+    virtual void FinishDataHandler(){
+      CalculateRunningAverage();
+    };
 
     virtual ~VQwDataHandler();
 
@@ -73,6 +79,8 @@ class VQwDataHandler:  virtual public VQwDataHandlerCloneable, public MQwPublish
 
     virtual void ClearEventData();
 
+    void InitRunningSum();
+    void AccumulateRunningSum();
     virtual void AccumulateRunningSum(VQwDataHandler &value, Int_t count = 0, Int_t ErrorMask = 0xFFFFFFF);
     void CalculateRunningAverage();
     void PrintValue() const;
@@ -170,6 +178,8 @@ class VQwDataHandler:  virtual public VQwDataHandlerCloneable, public MQwPublish
 
  protected:
    Bool_t fKeepRunningSum;
+   Bool_t fRunningsumFillsTree;
+   VQwDataHandler *fRunningsum;
 };
 
 #endif // VQWDATAHANDLER_H_

--- a/Parity/main/QwParity.cc
+++ b/Parity/main/QwParity.cc
@@ -406,6 +406,7 @@ Int_t main(Int_t argc, Char_t* argv[])
                 datahandlerarray_burst.FillTreeBranches(burstrootfile);
 
 		helicitypattern.IncrementBurstCounter();
+		datahandlerarray_mul.UpdateBurstCounter(helicitypattern.GetBurstCounter());
 		datahandlerarray_burst.UpdateBurstCounter(helicitypattern.GetBurstCounter());
                 // Clear the data
                 patternsum_per_burst.ClearEventData();
@@ -470,9 +471,7 @@ Int_t main(Int_t argc, Char_t* argv[])
 
     // Finish data handlers
     datahandlerarray_evt.FinishDataHandler();
-    datahandlerarray_evt.FillTreeBranches(treerootfile);
     datahandlerarray_mul.FinishDataHandler();
-    datahandlerarray_mul.FillTreeBranches(treerootfile);
 
     // Calculate running averages
     eventsum.CalculateRunningAverage();

--- a/Parity/src/LinReg_Bevington_Pebay.cc
+++ b/Parity/src/LinReg_Bevington_Pebay.cc
@@ -181,6 +181,9 @@ LinRegBevPeb& LinRegBevPeb::operator+=(const LinRegBevPeb& rhs)
   // on Scientific and Statistical Database Management.
   // https://doi.org/10.1145/3221269.3223036
 
+  if(fGoodEventNumber + rhs.fGoodEventNumber == 0)
+    return *this;
+
   // Deviations from mean
   TVectorD delta_y(mMY - rhs.mMY);
   TVectorD delta_p(mMP - rhs.mMP);

--- a/Parity/src/QwDataHandlerArray.cc
+++ b/Parity/src/QwDataHandlerArray.cc
@@ -180,7 +180,8 @@ void QwDataHandlerArray::LoadDataHandlersFromParameterFile(
     handler->ParseConfigFile(*section);
     handler->LoadChannelMap();
     handler->ConnectChannels(detectors);
-    
+    handler->InitRunningSum();
+
     // Add to array
     this->push_back(handler);
     /*    
@@ -688,6 +689,7 @@ void QwDataHandlerArray::ProcessDataHandlerEntry()
   if (!empty()) {
     for(iterator handler = begin(); handler != end(); ++handler){
       (*handler)->ProcessData();
+      (*handler)->AccumulateRunningSum();
     }
   }
 }
@@ -696,9 +698,8 @@ void QwDataHandlerArray::FinishDataHandler()
 {
   if (!empty()) {
     for(iterator handler = begin(); handler != end(); ++handler){
-      (*handler)->CalcCorrelations();
+      (*handler)->FinishDataHandler();
     }
-    this->CalculateRunningAverage();  
   }
 }
   


### PR DESCRIPTION
The correlator now has a cycle counter that increments each time
we write a set of outputs.  This is independent of the burst
counter, but for the "burst correlator" does increment when the
burst counter does.

The VQwDataHandler error flag pointer gets assigned at the same
time as the source pointer.

VQwDataHandler contains its own running sum; this provides some
consistency in behavior between the correlator and other data handlers,
although it is inconsistent with how running sums work for the
subsystem arrays and pattern object.