### PR TITLE
Updating burst definition to only increment the burst after N good patterns

### DIFF
--- a/Parity/src/QwHelicityPattern.cc
+++ b/Parity/src/QwHelicityPattern.cc
@@ -668,7 +668,9 @@ void QwHelicityPattern::ClearEventData()
 void  QwHelicityPattern::AccumulateRunningSum(QwHelicityPattern &entry, Int_t count, Int_t ErrorMask)
 {
   if (entry.fPatternIsGood){
-    fGoodPatterns++;
+    if ( (*(entry.fAsymmetry.GetEventcutErrorFlagPointer()) & ErrorMask) == 0 )  {
+      fGoodPatterns++;
+    }
     fBurstCounter = entry.fBurstCounter;
     fYield.AccumulateRunningSum(entry.fYield, count, ErrorMask);
     fAsymmetry.AccumulateRunningSum(entry.fAsymmetry, count, ErrorMask);


### PR DESCRIPTION
Updating burst definition to only increment the burst after N good patterns.

This needs to have an optional flag added to it to allow for the original N patterns (regardless of good) too.

This works: 
Bursts are 9k long (as desired)
![new-bursts](https://user-images.githubusercontent.com/12798552/70834021-3ef28500-1dc7-11ea-8489-3b3cfa1ebd2b.png)
Bursts are variable in length to include the right number of good patterns
![new-burst2](https://user-images.githubusercontent.com/12798552/70834026-40bc4880-1dc7-11ea-9812-653871924d24.png)

Here's what it was before, when the "good" pattern was only based on the analyzer's ability to actually create a pattern (without checking the internal data quality).
![oldBursts](https://user-images.githubusercontent.com/12798552/70834094-69dcd900-1dc7-11ea-89af-0920dc67838e.png)
