### PR TITLE
Fixes the issue with number of good events.

### DIFF
--- a/Parity/src/QwHelicityPattern.cc
+++ b/Parity/src/QwHelicityPattern.cc
@@ -182,6 +182,7 @@ QwHelicityPattern::QwHelicityPattern(const QwHelicityPattern &source)
   fPairAsymmetry(source.fYield),
   fBurstLength(source.fBurstLength),
   fGoodPatterns(source.fGoodPatterns),
+  fPatternSize(source.fPatternSize),
   fBurstCounter(source.fBurstCounter),
   fEnableBurstSum(source.fEnableBurstSum),
   fPrintBurstSum(source.fPrintBurstSum),


### PR DESCRIPTION
Added the fPatternSize variable to the copy constructor for QwHelicityPattern. There is still the possible frailty since it relies on "bcm_an_us" being a good variable to monitor good events. Considering a parameter to run range the name of the good current monitor (as far as i recall, this was changing over the course of PREX). That will be a robust fix. But this should work for now.