### PR TITLE
Adding a 0.5->1 pass final burst length feature

### DIFF
--- a/Parity/include/QwHelicityPattern.h
+++ b/Parity/include/QwHelicityPattern.h
@@ -65,7 +65,7 @@ class QwHelicityPattern {
 
   void PrintIndexMapFile(Int_t runNum){
     if ( fPrintIndexFile && (fGoodPatterns < fBurstMinGoodPatterns) ) {
-      // Print a text map file to max_burst_index.####.map
+      // Print a text map file to max_burst_index.####.conf
       Int_t maxBurst = 0;
       if (fBurstCounter==0) {
         // It's a single burst run anyway
@@ -75,10 +75,10 @@ class QwHelicityPattern {
         // It's a multi burst run and we want to merge the final two bursts
         maxBurst = fBurstCounter-1;
       }
-      QwWarning << "Printing max_burst_index." << runNum << ".map file with " << maxBurst << " max burst number" << QwLog::endl;
+      QwWarning << "Printing max_burst_index." << runNum << ".conf file with " << maxBurst << " max burst number" << QwLog::endl;
       std::ofstream output;
-      output.open(Form("max_burst_index.%d.map",runNum));
-      output<< maxBurst << std::endl; // Print the current index before incrementing further, this will be the max index and the next pass will overflow this one instead of having another
+      output.open(Form("max_burst_index.%d.conf",runNum));
+      output<< "max-burst-index=" << maxBurst << std::endl; // Print the current index before incrementing further, this will be the max index and the next pass will overflow this one instead of having another
       output.close();
     }
   }

--- a/Parity/include/QwHelicityPattern.h
+++ b/Parity/include/QwHelicityPattern.h
@@ -62,8 +62,8 @@ class QwHelicityPattern {
   Bool_t IsCompletePattern() const;
 
   Bool_t IsEndOfBurst(){
-    //  Is this the end of a burst?
-    return (fBurstLength > 0 && fGoodPatterns >= fBurstLength);
+    //  Is this the end of a burst? And is this not the final burst?
+    return (( fBurstLength > 0 && fGoodPatterns >= fBurstLength ) && ( fBurstCounter<fMaxBurstIndex ));
   }
 
   void  CalculateAsymmetry();
@@ -168,7 +168,12 @@ class QwHelicityPattern {
   };
 
   Bool_t HasBurstData(){return fGoodPatterns>0;};
-  void  IncrementBurstCounter(){fBurstCounter++;}
+  void  IncrementBurstCounter(){
+    if (fBurstCounter < fMaxBurstIndex) {
+      fBurstCounter++;
+    }
+    // Else we just park here and don't try to increment any more. This is a parameter from command line or map file
+  }
   Short_t GetBurstCounter() const {return fBurstCounter;}
   void  ClearEventData();
 
@@ -211,6 +216,7 @@ class QwHelicityPattern {
 
   // Burst sum/difference of the yield and asymmetry
   Int_t fBurstLength;
+  Int_t fMaxBurstIndex;
   Int_t fGoodPatterns;
   Short_t fBurstCounter;
   Bool_t fEnableBurstSum;

--- a/Parity/include/QwHelicityPattern.h
+++ b/Parity/include/QwHelicityPattern.h
@@ -63,13 +63,22 @@ class QwHelicityPattern {
 
   Bool_t IsCompletePattern() const;
 
-  void PrintIndex(Int_t runNum){
+  void PrintIndexMapFile(Int_t runNum){
     if ( fPrintIndexFile && (fGoodPatterns < fBurstMinGoodPatterns) ) {
       // Print a text map file to prmpinput/MaxBurstIndices/max_burst_index.####.map
-      QwWarning << "Printing MaxBurstIndices/max_burst_index." << runNum << ".map file with " << fBurstCounter << " max burst number" << QwLog::endl;
+      Int_t maxBurst = 0;
+      if (fBurstCounter==0) {
+        // It's a single burst run anyway
+        maxBurst = 0;
+      }
+      else {
+        // It's a multi burst run and we want to merge the final two bursts
+        maxBurst = fBurstCounter-1;
+      }
+      QwWarning << "Printing MaxBurstIndices/max_burst_index." << runNum << ".map file with " << maxBurst << " max burst number" << QwLog::endl;
       std::ofstream output;
       output.open(Form("MaxBurstIndices/max_burst_index.%d.map",runNum));
-      output<< fBurstCounter << std::endl; // Print the current index before incrementing further, this will be the max index and the next pass will overflow this one instead of having another
+      output<< maxBurst << std::endl; // Print the current index before incrementing further, this will be the max index and the next pass will overflow this one instead of having another
       output.close();
     }
   }

--- a/Parity/include/QwHelicityPattern.h
+++ b/Parity/include/QwHelicityPattern.h
@@ -65,7 +65,7 @@ class QwHelicityPattern {
 
   void PrintIndexMapFile(Int_t runNum){
     if ( fPrintIndexFile && (fGoodPatterns < fBurstMinGoodPatterns) ) {
-      // Print a text map file to prmpinput/MaxBurstIndices/max_burst_index.####.map
+      // Print a text map file to max_burst_index.####.map
       Int_t maxBurst = 0;
       if (fBurstCounter==0) {
         // It's a single burst run anyway
@@ -75,9 +75,9 @@ class QwHelicityPattern {
         // It's a multi burst run and we want to merge the final two bursts
         maxBurst = fBurstCounter-1;
       }
-      QwWarning << "Printing MaxBurstIndices/max_burst_index." << runNum << ".map file with " << maxBurst << " max burst number" << QwLog::endl;
+      QwWarning << "Printing max_burst_index." << runNum << ".map file with " << maxBurst << " max burst number" << QwLog::endl;
       std::ofstream output;
-      output.open(Form("MaxBurstIndices/max_burst_index.%d.map",runNum));
+      output.open(Form("max_burst_index.%d.map",runNum));
       output<< maxBurst << std::endl; // Print the current index before incrementing further, this will be the max index and the next pass will overflow this one instead of having another
       output.close();
     }

--- a/Parity/include/QwHelicityPattern.h
+++ b/Parity/include/QwHelicityPattern.h
@@ -9,6 +9,8 @@
 
 // System headers
 #include <vector>
+#include <iostream>
+#include <fstream>
 
 // ROOT headers
 #include <TTree.h>
@@ -60,6 +62,17 @@ class QwHelicityPattern {
   }
 
   Bool_t IsCompletePattern() const;
+
+  void PrintIndex(Int_t runNum){
+    if ( fPrintIndexFile && (fGoodPatterns < fBurstMinGoodPatterns) ) {
+      // Print a text map file to prmpinput/MaxBurstIndices/max_burst_index.####.map
+      QwWarning << "Printing MaxBurstIndices/max_burst_index." << runNum << ".map file with " << fBurstCounter << " max burst number" << QwLog::endl;
+      std::ofstream output;
+      output.open(Form("MaxBurstIndices/max_burst_index.%d.map",runNum));
+      output<< fBurstCounter << std::endl; // Print the current index before incrementing further, this will be the max index and the next pass will overflow this one instead of having another
+      output.close();
+    }
+  }
 
   Bool_t IsEndOfBurst(){
     //  Is this the end of a burst? And is this not the final burst?
@@ -217,6 +230,8 @@ class QwHelicityPattern {
   // Burst sum/difference of the yield and asymmetry
   Int_t fBurstLength;
   Int_t fMaxBurstIndex;
+  Bool_t fPrintIndexFile;
+  Int_t fBurstMinGoodPatterns;
   Int_t fGoodPatterns;
   Short_t fBurstCounter;
   Bool_t fEnableBurstSum;

--- a/Parity/main/QwParity.cc
+++ b/Parity/main/QwParity.cc
@@ -99,11 +99,12 @@ Int_t main(Int_t argc, Char_t* argv[])
   //  QwPromptSummary promptsummary;
 
   ///  Start loop over all runs
+  Int_t run_number = 0;
   while (eventbuffer.OpenNextStream() == CODA_OK) {
 
     ///  Begin processing for the first run
 
-    Int_t run_number = eventbuffer.GetRunNumber();
+    run_number = eventbuffer.GetRunNumber();
     TString run_label = eventbuffer.GetRunLabel();
 
     ///  Set the current event number for parameter file lookup
@@ -460,6 +461,7 @@ Int_t main(Int_t argc, Char_t* argv[])
 
       // Fill data handler tree branches
       datahandlerarray_burst.FillTreeBranches(burstrootfile);
+      patternsum_per_burst.PrintIndex(run_number);
     }
 
     //  Perform actions at the end of the event loop on the

--- a/Parity/main/QwParity.cc
+++ b/Parity/main/QwParity.cc
@@ -461,7 +461,7 @@ Int_t main(Int_t argc, Char_t* argv[])
 
       // Fill data handler tree branches
       datahandlerarray_burst.FillTreeBranches(burstrootfile);
-      patternsum_per_burst.PrintIndex(run_number);
+      patternsum_per_burst.PrintIndexMapFile(run_number);
     }
 
     //  Perform actions at the end of the event loop on the

--- a/Parity/src/QwHelicityPattern.cc
+++ b/Parity/src/QwHelicityPattern.cc
@@ -53,6 +53,10 @@ void QwHelicityPattern::DefineOptions(QwOptions &options)
     ("burstlength", po::value<int>()->default_value(9000),
      "number of patterns per burst");
 
+  options.AddOptions("Helicity pattern")
+    ("max-burst-index", po::value<int>()->default_value(0x7fffffff), // Default to max signed int
+     "max number of bursts for a run");
+
   QwBlinder::DefineOptions(options);
 }
 
@@ -69,6 +73,9 @@ void QwHelicityPattern::ProcessOptions(QwOptions &options)
 
   fBurstLength = options.GetValue<int>("burstlength");
   if (fBurstLength == 0) DisableBurstSum();
+
+  fMaxBurstIndex = options.GetValue<int>("max-burst-index");
+//  if (fMaxBurstIndex != 0x7fffffff) do something ;
 
   if (fEnableAlternateAsym && fPatternSize <= 2){
     QwWarning << "QwHelicityPattern::ProcessOptions: "
@@ -96,6 +103,7 @@ QwHelicityPattern::QwHelicityPattern(QwSubsystemArrayParity &event, const TStrin
     fPairDifference(event), 
     fPairAsymmetry(event),
     fBurstLength(0),
+    fMaxBurstIndex(0x7fffffff),
     fGoodPatterns(0),
     fBurstCounter(0),
     fEnableBurstSum(kFALSE),
@@ -181,6 +189,7 @@ QwHelicityPattern::QwHelicityPattern(const QwHelicityPattern &source)
   fPairDifference(source.fYield),
   fPairAsymmetry(source.fYield),
   fBurstLength(source.fBurstLength),
+  fMaxBurstIndex(source.fMaxBurstIndex),
   fGoodPatterns(source.fGoodPatterns),
   fPatternSize(source.fPatternSize),
   fBurstCounter(source.fBurstCounter),

--- a/Parity/src/QwHelicityPattern.cc
+++ b/Parity/src/QwHelicityPattern.cc
@@ -57,6 +57,14 @@ void QwHelicityPattern::DefineOptions(QwOptions &options)
     ("max-burst-index", po::value<int>()->default_value(0x7fffffff), // Default to max signed int
      "max number of bursts for a run");
 
+  options.AddOptions("Helicity pattern")
+    ("print-burst-index-map", po::value<bool>()->default_value(kFALSE),
+     "whether to print the shorter max burst index if the final is shorter than min-burstlength");
+
+  options.AddOptions("Helicity pattern")
+    ("min-burstlength", po::value<int>()->default_value(2333), // Default 1/4 of 9000
+     "minimum acceptable burst length");
+
   QwBlinder::DefineOptions(options);
 }
 
@@ -74,8 +82,9 @@ void QwHelicityPattern::ProcessOptions(QwOptions &options)
   fBurstLength = options.GetValue<int>("burstlength");
   if (fBurstLength == 0) DisableBurstSum();
 
-  fMaxBurstIndex = options.GetValue<int>("max-burst-index");
-//  if (fMaxBurstIndex != 0x7fffffff) do something ;
+  fMaxBurstIndex        = options.GetValue<int>("max-burst-index");
+  fPrintIndexFile       = options.GetValue<bool>("print-burst-index-map");
+  fBurstMinGoodPatterns = options.GetValue<int>("min-burstlength");
 
   if (fEnableAlternateAsym && fPatternSize <= 2){
     QwWarning << "QwHelicityPattern::ProcessOptions: "
@@ -104,6 +113,8 @@ QwHelicityPattern::QwHelicityPattern(QwSubsystemArrayParity &event, const TStrin
     fPairAsymmetry(event),
     fBurstLength(0),
     fMaxBurstIndex(0x7fffffff),
+    fPrintIndexFile(kFALSE),
+    fBurstMinGoodPatterns(0),
     fGoodPatterns(0),
     fBurstCounter(0),
     fEnableBurstSum(kFALSE),
@@ -190,6 +201,8 @@ QwHelicityPattern::QwHelicityPattern(const QwHelicityPattern &source)
   fPairAsymmetry(source.fYield),
   fBurstLength(source.fBurstLength),
   fMaxBurstIndex(source.fMaxBurstIndex),
+  fPrintIndexFile(source.fPrintIndexFile),
+  fBurstMinGoodPatterns(source.fBurstMinGoodPatterns),
   fGoodPatterns(source.fGoodPatterns),
   fPatternSize(source.fPatternSize),
   fBurstCounter(source.fBurstCounter),


### PR DESCRIPTION
So far it just lets the user specify from the command line.

Want to have a max-burst-index conf file printer function (probably triggered by a command line option as well) for a hypothetical 0.5 pass initial run to give N bursts - 1 as output for a proper 1st pass to have the correct number of bursts in it (be careful that this doesn't persist into future respins, as cuts can change the amount of good data in a run independently of pass 0.5, 1, 2, etc.).

Want to have a numerical-merging of N and N-1 bursts slope outputs so that they can be used from the 0.5 pass directly onto 2nd pass outputs (saving an entire 1st pass root file printing procedure and only pushing fully corrected data 5 minutes down the line).