### PR TITLE
Modify bpm setting in some beamline_eventcuts map files

### DIFF
--- a/Parity/prminput/prexCH_beamline_eventcuts.2948-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.2948-.map
@@ -49,7 +49,14 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bpmstripline,	bpm4a,	ym,	10000,	50000,	l
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a, 	xp, 	1000, 	55000, 	g,  	0,  	1000
+ bpmstripline, 	bpm4a, 	ym, 	10000, 	55000, 	g,  	0,  	1000
+ bpmstripline, 	bpm4a, 	yp, 	1000, 	55000, 	g,  	0,  	1000
+ bpmstripline, 	bpm4e, 	xm, 	1000, 	55000, 	g,  	0,  	1000
+ bpmstripline, 	bpm4e, 	xp, 	1000, 	55000, 	g,  	0,  	1000
+ bpmstripline, 	bpm4e, 	ym, 	1000, 	55000, 	g,  	0,  	1000
+ bpmstripline, 	bpm4e, 	yp, 	1000, 	55000, 	g,  	0,  	1000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000

--- a/Parity/prminput/prexCH_beamline_eventcuts.3139.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3139.map
@@ -49,7 +49,14 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bpmstripline,	bpm4a,	ym,	10000,	50000,	l
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a, 	xp, 	1000, 	55000, 	g,  	0,  	1000
+ bpmstripline, 	bpm4a, 	ym, 	10000, 	55000, 	g,  	0,  	1000
+ bpmstripline, 	bpm4a, 	yp, 	1000, 	55000, 	g,  	0,  	1000
+ bpmstripline, 	bpm4e, 	xm, 	1000, 	55000, 	g,  	0,  	1000
+ bpmstripline, 	bpm4e, 	xp, 	1000, 	55000, 	g,  	0,  	1000
+ bpmstripline, 	bpm4e, 	ym, 	1000, 	55000, 	g,  	0,  	1000
+ bpmstripline, 	bpm4e, 	yp, 	1000, 	55000, 	g,  	0,  	1000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000

--- a/Parity/prminput/prexCH_beamline_eventcuts.3289-3292.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3289-3292.map
@@ -61,15 +61,15 @@ EVENTCUTS = 3
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm14,	xm,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm14,	xp,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm14,	ym,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm14,	yp,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm8,	xm,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm8,	xp,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm8,	ym,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm8,	yp,	1000,	55000,	g,	0,	1000
+! bpmstripline,	bpm14,	xm,	1000,	55000,	g,	0,	1000
+! bpmstripline,	bpm14,	xp,	1000,	55000,	g,	0,	1000
+! bpmstripline,	bpm14,	ym,	1000,	55000,	g,	0,	1000
+! bpmstripline,	bpm14,	yp,	1000,	55000,	g,	0,	1000
+! bpmstripline,	bpm8,	xm,	1000,	55000,	g,	0,	1000
+! bpmstripline,	bpm8,	xp,	1000,	55000,	g,	0,	1000
+! bpmstripline,	bpm8,	ym,	1000,	55000,	g,	0,	1000
+! bpmstripline,	bpm8,	yp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.35,	0.35
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.35,	0.35
- bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.35,	0.35
- bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.35,	0.35
+ bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.35,	0.35
+ bpmstripline,	bpm4e,	absy,	-200,	200,	g,	0.35,	0.35

--- a/Parity/prminput/prexCH_beamline_eventcuts.3403.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3403.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds,	35,	1e6,	g,	1.2
+ bcm,	bcm_an_ds,	35,	1e6,	g,	1
 
 
 
@@ -61,15 +61,4 @@ EVENTCUTS = 3
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
-! bpmstripline,	bpm14,	xm,	1000,	55000,	g,	0,	1000
-! bpmstripline,	bpm14,	xp,	1000,	55000,	g,	0,	1000
-! bpmstripline,	bpm14,	ym,	1000,	55000,	g,	0,	1000
-! bpmstripline,	bpm14,	yp,	1000,	55000,	g,	0,	1000
-! bpmstripline,	bpm8,	xm,	1000,	55000,	g,	0,	1000
-! bpmstripline,	bpm8,	xp,	1000,	55000,	g,	0,	1000
-! bpmstripline,	bpm8,	ym,	1000,	55000,	g,	0,	1000
-! bpmstripline,	bpm8,	yp,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.35,	0.35
- bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.35,	0.35
- bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.35,	0.35
- bpmstripline,	bpm4e,	absy,	-200,	200,	g,	0.35,	0.35
+ bpmstripline,	bpm4e,	absx,	-1,	1,	g

--- a/Parity/prminput/prexCH_beamline_eventcuts.3404-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3404-.map
@@ -65,4 +65,3 @@ EVENTCUTS = 3
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000
- bpmstripline,	bpm4e,	absx,	-1,	1,	g

--- a/Parity/prminput/prexCH_beamline_eventcuts.3425-3428.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3425-3428.map
@@ -49,7 +49,18 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bpmstripline,	bpm4a,	ym,	10000,	50000,	l
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	10000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000

--- a/Parity/prminput/prexCH_beamline_eventcuts.3450-3452.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3450-3452.map
@@ -57,6 +57,10 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000

--- a/Parity/prminput/prexCH_beamline_eventcuts.3455.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3455.map
@@ -57,6 +57,10 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000

--- a/Parity/prminput/prexCH_beamline_eventcuts.3489.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3489.map
@@ -57,6 +57,10 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000

--- a/Parity/prminput/prexCH_beamline_eventcuts.3524.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3524.map
@@ -57,6 +57,10 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000

--- a/Parity/prminput/prexCH_beamline_eventcuts.3540.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3540.map
@@ -57,6 +57,10 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000


### PR DESCRIPTION
make sure bpm 4a, 4e and 12 appear in all beamline_eventcuts map files,
and 11 doesn't appears in map files before
prexCH_beamline_eventcuts.3403.map (included) and appears
in all map files after prexCH_beamline_eventcuts.3404-.map (included)