### PR TITLE
Hotfix to allow selecting run-dependent blindable target positions.

### DIFF
--- a/Parity/include/QwBlinder.h
+++ b/Parity/include/QwBlinder.h
@@ -244,7 +244,12 @@ class QwBlinder {
     void SetWienState(EQwWienMode wienmode);
     void SetIHWPPolarity(Int_t ihwppolarity);
 
-    Bool_t fUseCREXPositions;
+    //  Target position look-up index for PREX/CREX.
+    //  Index value of -1 is for the PREX positons
+    //  CREX index values in date order go from "min" to "Max" and must correspond to cases in the QwBlinder::Update(const QwEPICSEvent& epics) function.
+    Int_t  fCREXTargetIndex;
+    Int_t  kCREXTgtIndexMin = 1;
+    Int_t  kCREXTgtIndexMax = 2;
 
     Double_t fBeamCurrentThreshold;
     Bool_t fBeamIsPresent;

--- a/Parity/prminput/blinder.5104-5274.map
+++ b/Parity/prminput/blinder.5104-5274.map
@@ -12,4 +12,4 @@ max_asymmetry = 0.900
 # max_factor = positive float fraction such that multiplicative blinding asymmetry is between 1 +/- (this value)
 max_factor = 0.0
 
-use_crex_target_position = true
+crex_target_index = 1

--- a/Parity/prminput/blinder.5275-.map
+++ b/Parity/prminput/blinder.5275-.map
@@ -12,4 +12,4 @@ max_asymmetry = 0.900
 # max_factor = positive float fraction such that multiplicative blinding asymmetry is between 1 +/- (this value)
 max_factor = 0.0
 
-use_crex_target_position = true
+crex_target_index = 1


### PR DESCRIPTION
This extends the mechanic that we used to differentiate between the PREX and
CREX taret position ranges to allow more than two sets of blindable target
ranges.
The PREX positions are associated to target index "-1", and the CREX positions
to date are index "1".  The new CREX target encoder position will be "2", and we
can easily define more later if needed (like if the encoder changes).