### PR TITLE
Feature crex respin1 device cuts

### DIFF
--- a/Parity/prminput/prexCH_beamline_eventcuts.5376-5420.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.5376-5420.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	20,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -47,6 +48,10 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm1, 	xm,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	xp,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	ym,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	yp,	-55000,	-1000,	g,	0,	0
  bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	2000
@@ -63,6 +68,8 @@ EVENTCUTS = 3
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
+! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.5412.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.5412.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	5,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -47,6 +48,10 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm1, 	xm,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	xp,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	ym,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	yp,	-55000,	-1000,	g,	0,	0
  bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	2000
@@ -63,6 +68,8 @@ EVENTCUTS = 3
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
+! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.5415.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.5415.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	5,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -47,6 +48,10 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm1, 	xm,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	xp,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	ym,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	yp,	-55000,	-1000,	g,	0,	0
  bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	2000
@@ -63,6 +68,8 @@ EVENTCUTS = 3
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
+! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.5421-5869.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.5421-5869.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	120,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -47,6 +48,10 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm1, 	xm,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	xp,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	ym,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	yp,	-55000,	-1000,	g,	0,	0
  bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	2000
@@ -55,14 +60,16 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
+! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.5460.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.5460.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	120,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -47,6 +48,10 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm1, 	xm,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	xp,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	ym,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	yp,	-55000,	-1000,	g,	0,	0
  bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	2000
@@ -55,14 +60,16 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
+! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4e,	absx,	-200,	0.3,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.5464.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.5464.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	120,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -47,6 +48,10 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm1, 	xm,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	xp,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	ym,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	yp,	-55000,	-1000,	g,	0,	0
  bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	2000
@@ -55,14 +60,16 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
+! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4e,	absx,	-200,	0.3,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.5472.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.5472.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	120,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -47,6 +48,10 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm1, 	xm,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	xp,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	ym,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	yp,	-55000,	-1000,	g,	0,	0
  bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	2000
@@ -55,14 +60,16 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
+! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4e,	absx,	-200,	0.3,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.5484.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.5484.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	80,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,  -10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -47,6 +48,10 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm1, 	xm,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	xp,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	ym,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	yp,	-55000,	-1000,	g,	0,	0
  bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	2000
@@ -63,6 +68,8 @@ EVENTCUTS = 3
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
+! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.5637.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.5637.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	120,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -47,6 +48,10 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm1, 	xm,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	xp,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	ym,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	yp,	-55000,	-1000,	g,	0,	0
  bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	2000
@@ -55,14 +60,16 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
+! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4e,	absx,	-200,	0.3,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.5870-5907.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.5870-5907.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	25,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -47,6 +48,10 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm1, 	xm,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	xp,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	ym,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	yp,	-55000,	-1000,	g,	0,	0
  bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	2000
@@ -55,14 +60,16 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
+! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.5908-5912.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.5908-5912.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	80,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -47,6 +48,10 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm1, 	xm,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	xp,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	ym,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	yp,	-55000,	-1000,	g,	0,	0
  bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	2000
@@ -55,14 +60,16 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
+! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.5913-5938.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.5913-5938.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	110,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -47,6 +48,10 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm1, 	xm,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	xp,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	ym,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	yp,	-55000,	-1000,	g,	0,	0
  bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	2000
@@ -55,14 +60,16 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
+! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.5939-5940.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.5939-5940.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	50,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -47,6 +48,10 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm1, 	xm,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	xp,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	ym,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	yp,	-55000,	-1000,	g,	0,	0
  bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	2000
@@ -55,14 +60,16 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
+! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.5941-5944.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.5941-5944.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	110,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -47,6 +48,10 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm1, 	xm,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	xp,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	ym,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	yp,	-55000,	-1000,	g,	0,	0
  bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	2000
@@ -55,14 +60,16 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
+! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.5945-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.5945-.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	120,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -47,6 +48,10 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm1, 	xm,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	xp,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	ym,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	yp,	-55000,	-1000,	g,	0,	0
  bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	2000
@@ -55,14 +60,16 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
+! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.5963.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.5963.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	120,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -47,6 +48,10 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm1, 	xm,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	xp,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	ym,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	yp,	-55000,	-1000,	g,	0,	0
  bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	2000
@@ -55,14 +60,16 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
+! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4e,	absx,	-200,	0.3,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.6032.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.6032.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	90,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -47,6 +48,10 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm1, 	xm,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	xp,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	ym,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	yp,	-55000,	-1000,	g,	0,	0
  bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	2000
@@ -55,14 +60,16 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
+! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.6046.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.6046.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	10,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -47,6 +48,10 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm1, 	xm,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	xp,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	ym,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	yp,	-55000,	-1000,	g,	0,	0
  bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	2000
@@ -55,14 +60,16 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
+! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.6177-6181.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.6177-6181.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	105,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -47,6 +48,10 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm1, 	xm,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	xp,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	ym,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	yp,	-55000,	-1000,	g,	0,	0
  bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	2000
@@ -55,14 +60,16 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
+! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.6182-6490.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.6182-6490.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	120,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -47,6 +48,10 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm1, 	xm,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	xp,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	ym,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	yp,	-55000,	-1000,	g,	0,	0
  bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	2000
@@ -55,14 +60,16 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
+! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.6242.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.6242.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	80,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -47,6 +48,10 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm1, 	xm,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	xp,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	ym,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	yp,	-55000,	-1000,	g,	0,	0
  bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	2000
@@ -55,14 +60,16 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
+! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.6366-6378.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.6366-6378.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	50,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -47,6 +48,10 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm1, 	xm,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	xp,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	ym,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	yp,	-55000,	-1000,	g,	0,	0
  bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	2000
@@ -55,14 +60,16 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
+! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4e,	absx,	-200,	200,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.6491-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.6491-.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	120,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -59,14 +60,15 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
 ! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.6495-6504.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.6495-6504.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	80,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -59,14 +60,15 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
 ! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.6495.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.6495.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	3,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -47,10 +48,10 @@ EVENTCUTS = 3
 !So pedestals are applied before appyling the cuts.
 
 !device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bpmstripline,	bpm1, 	xm,	-55000,	1000,	g,	0,	0
- bpmstripline,	bpm1, 	xp,	-55000,	1000,	g,	0,	0
- bpmstripline,	bpm1, 	ym,	-55000,	1000,	g,	0,	0
- bpmstripline,	bpm1, 	yp,	-55000,	1000,	g,	0,	0
+ bpmstripline,	bpm1, 	xm,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	xp,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	ym,	-55000,	-1000,	g,	0,	0
+ bpmstripline,	bpm1, 	yp,	-55000,	-1000,	g,	0,	0
  bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	2000
@@ -59,14 +60,15 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
 ! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.7

--- a/Parity/prminput/prexCH_beamline_eventcuts.6571-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.6571-.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	120,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -59,14 +60,15 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
 ! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.2

--- a/Parity/prminput/prexCH_beamline_eventcuts.6587.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.6587.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	120,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -59,14 +60,15 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
 ! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.2

--- a/Parity/prminput/prexCH_beamline_eventcuts.6709-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.6709-.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	100,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -59,14 +60,15 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
 ! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.2

--- a/Parity/prminput/prexCH_beamline_eventcuts.6733.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.6733.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	55,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -59,14 +60,15 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
 ! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.2

--- a/Parity/prminput/prexCH_beamline_eventcuts.6987.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.6987.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	110,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -59,14 +60,15 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
 ! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.2

--- a/Parity/prminput/prexCH_beamline_eventcuts.6988.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.6988.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	110,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -59,14 +60,15 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
 ! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.2

--- a/Parity/prminput/prexCH_beamline_eventcuts.6989.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.6989.map
@@ -39,6 +39,7 @@ EVENTCUTS = 3
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
 
  bcm,	bcm_an_us,	110,	1e6,	g,	1.7
+ bcm,	bcm_an_ds,	-10,	1e6,	g
 
 !****************************************************				
 !for bpmstrpline devices
@@ -59,14 +60,15 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
-!bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	2000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	2000
  bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	2000
+
 ! For Target Protection, etc.
  bpmstripline,	bpm4a,	absx,	-200,	200,	g,	0.7,	0.7
  bpmstripline,	bpm4a,	absy,	-200,	200,	g,	0.7,	0.2

--- a/Parity/prminput/prex_maindet_eventcuts.5636-.map
+++ b/Parity/prminput/prex_maindet_eventcuts.5636-.map
@@ -1,13 +1,13 @@
-! For runs 6105 to 6110 (LHRS trips) - want to local cut the main LHRS detectors
+! For runs 3564 and 3565 (HV off left, Quads off Right) - want to local cut the main RHRS detectors, global cut the main LHRS detectors
 
 EVENTCUTS = 3
-IntegrationPMT, usl,		-100000,	100000,	l,	0
+IntegrationPMT, usl,		-100000,	100000,	g,	0
 IntegrationPMT, dsl,		-100000,	100000,	l,	0
 IntegrationPMT, usr,		-100000,	100000,	g,	0
 IntegrationPMT, dsr,		-100000,	100000,	l,	0
 
 ! Start using ATs in global error flag - http://ace.phys.virginia.edu/HAPPEX/4058
-IntegrationPMT, atl1,		-100000,	120000,	l,	0
-IntegrationPMT, atl2,		-100000,	120000,	l,	0
+IntegrationPMT, atl1,		-100000,	120000,	g,	0
+IntegrationPMT, atl2,		-100000,	120000,	g,	0
 IntegrationPMT, atr1,		-100000,	120000,	g,	0
 IntegrationPMT, atr2,		-100000,	120000,	g,	0

--- a/rootScripts/merger/smartHadd_miniruns_AT_regression.sh
+++ b/rootScripts/merger/smartHadd_miniruns_AT_regression.sh
@@ -1,0 +1,34 @@
+#! /bin/sh
+ROOTFILEDIR="/chafs2/work1/apar/aggRootfiles/AT/minirun_aggregator_#_#.root"
+OUTPUTROOTFILEDIR="/chafs2/work1/apar/aggRootfiles/AT/slugRootfiles/"
+#OUTPUTROOTFILEDIR="./"
+if [ "$#" -lt 1 ]; then
+  echo "Error: Need to pass a list file name"
+  echo "Usage: ./smartHadd_miniruns_regression.sh list.txt (input file list, \\n separated) outputFileName (a name..., optional argument)"
+else
+  IFS=$'\n' read -d '' -r -a lines < ${1}
+  # all lines
+  echo "Hadding all runs: ${lines[@]}"
+  #minirun_lines=("${lines[@]}")
+  minirun_lines=()
+  #run_lines=("${lines[@]}")
+  num_lines=0
+  num_miniruns=0
+
+  # Do miniruns
+  for i in "${!lines[@]}"; do
+  #  run_temp="${ROOTFILEDIR}/grandRootfile_${lines[$i]}/grand_aggregator.root"
+    #run_lines[$i]=$run_temp
+    num_lines=$i
+  done
+
+  slug=`rcnd ${lines[0]} slug`
+  name=minirun_slug${slug}.root
+  if [ "$#" -ge 2 ]; then
+    name=$2
+  fi
+  root -l -b -q ~/PREX/japan/rootScripts/merger/smartHadd_miniruns.C\(\"${1}\",\"${ROOTFILEDIR}\",\"${OUTPUTROOTFILEDIR}/${name}\",\"run_number\",\"minirun_n\",\"agg\"\)
+
+  # Add units
+  root -l -b -q ~/PREX/prompt/Aggregator/wrapper/addUnits.C\(\"${OUTPUTROOTFILEDIR}/${name}\"\)
+fi

--- a/rootScripts/merger/smartHadd_miniruns_CREX_regression.sh
+++ b/rootScripts/merger/smartHadd_miniruns_CREX_regression.sh
@@ -1,0 +1,33 @@
+#! /bin/sh
+ROOTFILEDIR="/chafs2/work1/apar/aggRootfiles/slugRootfiles/minirun_slug#.root"
+OUTPUTROOTFILEDIR="/chafs2/work1/apar/aggRootfiles/slugRootfiles/grandRootfile/"
+#OUTPUTROOTFILEDIR="./"
+if [ "$#" -lt 1 ]; then
+  echo "Error: Need to pass a list file name \"....\".list"
+  echo "Usage: ./smartHadd_slug_regression.sh list.txt (input file list, \\n separated) outputFileName (a name..., optional argument)"
+else
+  IFS=$'\n' read -d '' -r -a lines < ${1}
+  # all lines
+  echo "Hadding all runs: ${lines[@]}"
+  #minirun_lines=("${lines[@]}")
+  minirun_lines=()
+  #run_lines=("${lines[@]}")
+  num_lines=0
+  num_miniruns=0
+
+  # Do miniruns
+  for i in "${!lines[@]}"; do
+  #  run_temp="${ROOTFILEDIR}/grandRootfile_${lines[$i]}/grand_aggregator.root"
+    #run_lines[$i]=$run_temp
+    num_lines=$i
+  done
+
+  name="${lines[0]}-${lines[$num_lines]}"
+  if [ "$#" -ge 2 ]; then
+    name=$2
+  fi
+  root -l -b -q ~/PREX/japan/rootScripts/merger/smartHadd.C\(\"${1}\",\"${ROOTFILEDIR}\",\"${OUTPUTROOTFILEDIR}/grand_CREX_${name}.root\",\"run_number\",\"minirun_n\",\"agg\"\)
+
+  # Add units
+  root -l -b -q ~/PREX/prompt/Aggregator/wrapper/addUnits.C\(\"${OUTPUTROOTFILEDIR}/grand_CREX_${name}.root\"\)
+fi

--- a/rootScripts/merger/smartHadd_miniruns_PQB.sh
+++ b/rootScripts/merger/smartHadd_miniruns_PQB.sh
@@ -1,0 +1,34 @@
+#! /bin/sh
+ROOTFILEDIR="/chafs2/work1/apar/aggRootfiles/PQB/minirun_aggregator_#_#.root"
+OUTPUTROOTFILEDIR="/chafs2/work1/apar/aggRootfiles/slugRootfiles/PQB/"
+#OUTPUTROOTFILEDIR="./"
+if [ "$#" -lt 1 ]; then
+  echo "Error: Need to pass a list file name"
+  echo "Usage: ./smartHadd_miniruns_dithering.sh list.txt (input file list, \\n separated) outputFileName (a name..., optional argument)"
+else
+  IFS=$'\n' read -d '' -r -a lines < ${1}
+  # all lines
+  echo "Hadding all runs: ${lines[@]}"
+  #minirun_lines=("${lines[@]}")
+  minirun_lines=()
+  #run_lines=("${lines[@]}")
+  num_lines=0
+  num_miniruns=0
+
+  # Do miniruns
+  for i in "${!lines[@]}"; do
+  #  run_temp="${ROOTFILEDIR}/grandRootfile_${lines[$i]}/grand_aggregator.root"
+    #run_lines[$i]=$run_temp
+    num_lines=$i
+  done
+
+  slug=`rcnd ${lines[0]} slug`
+  name=minirun_slug${slug}.root
+  if [ "$#" -ge 2 ]; then
+    name=$2
+  fi
+  root -l -b -q ~/PREX/japan/rootScripts/merger/smartHadd_miniruns.C\(\"${1}\",\"${ROOTFILEDIR}\",\"${OUTPUTROOTFILEDIR}/${name}\",\"run_number\",\"minirun_n\",\"agg\"\)
+
+  # Add units
+  root -l -b -q ~/PREX/prompt/Aggregator/wrapper/addUnits.C\(\"${OUTPUTROOTFILEDIR}/${name}\"\)
+fi

--- a/rootScripts/merger/smartHadd_miniruns_PREX_regression.sh
+++ b/rootScripts/merger/smartHadd_miniruns_PREX_regression.sh
@@ -1,0 +1,33 @@
+#! /bin/sh
+ROOTFILEDIR="/chafs2/work1/apar/aggRootfiles/PREXII_slugRootfiles/minirun_slug#.root"
+OUTPUTROOTFILEDIR="/chafs2/work1/apar/aggRootfiles/PREXII_slugRootfiles/grandRootfile/"
+#OUTPUTROOTFILEDIR="./"
+if [ "$#" -lt 1 ]; then
+  echo "Error: Need to pass a list file name \"....\".list"
+  echo "Usage: ./smartHadd_slug_regression.sh list.txt (input file list, \\n separated) outputFileName (a name..., optional argument)"
+else
+  IFS=$'\n' read -d '' -r -a lines < ${1}
+  # all lines
+  echo "Hadding all runs: ${lines[@]}"
+  #minirun_lines=("${lines[@]}")
+  minirun_lines=()
+  #run_lines=("${lines[@]}")
+  num_lines=0
+  num_miniruns=0
+
+  # Do miniruns
+  for i in "${!lines[@]}"; do
+  #  run_temp="${ROOTFILEDIR}/grandRootfile_${lines[$i]}/grand_aggregator.root"
+    #run_lines[$i]=$run_temp
+    num_lines=$i
+  done
+
+  name="${lines[0]}-${lines[$num_lines]}"
+  if [ "$#" -ge 2 ]; then
+    name=$2
+  fi
+  root -l -b -q ~/PREX/japan/rootScripts/merger/smartHadd.C\(\"${1}\",\"${ROOTFILEDIR}\",\"${OUTPUTROOTFILEDIR}/grand_PREX_${name}.root\",\"run_number\",\"minirun_n\",\"agg\"\)
+
+  # Add units
+  root -l -b -q ~/PREX/prompt/Aggregator/wrapper/addUnits.C\(\"${OUTPUTROOTFILEDIR}/grand_PREX_${name}.root\"\)
+fi

--- a/rootScripts/merger/smartHadd_miniruns_burp_regression.sh
+++ b/rootScripts/merger/smartHadd_miniruns_burp_regression.sh
@@ -1,0 +1,34 @@
+#! /bin/sh
+ROOTFILEDIR="/chafs2/work1/apar/aggRootfiles/burp/minirun_aggregator_#_#.root"
+OUTPUTROOTFILEDIR="/chafs2/work1/apar/aggRootfiles/burp/slugRootfiles/"
+#OUTPUTROOTFILEDIR="./"
+if [ "$#" -lt 1 ]; then
+  echo "Error: Need to pass a list file name"
+  echo "Usage: ./smartHadd_miniruns_regression.sh list.txt (input file list, \\n separated) outputFileName (a name..., optional argument)"
+else
+  IFS=$'\n' read -d '' -r -a lines < ${1}
+  # all lines
+  echo "Hadding all runs: ${lines[@]}"
+  #minirun_lines=("${lines[@]}")
+  minirun_lines=()
+  #run_lines=("${lines[@]}")
+  num_lines=0
+  num_miniruns=0
+
+  # Do miniruns
+  for i in "${!lines[@]}"; do
+  #  run_temp="${ROOTFILEDIR}/grandRootfile_${lines[$i]}/grand_aggregator.root"
+    #run_lines[$i]=$run_temp
+    num_lines=$i
+  done
+
+  slug=`rcnd ${lines[0]} slug`
+  name=minirun_slug${slug}.root
+  if [ "$#" -ge 2 ]; then
+    name=$2
+  fi
+  root -l -b -q ~/PREX/japan/rootScripts/merger/smartHadd_miniruns.C\(\"${1}\",\"${ROOTFILEDIR}\",\"${OUTPUTROOTFILEDIR}/${name}\",\"run_number\",\"minirun_n\",\"agg\"\)
+
+  # Add units
+  root -l -b -q ~/PREX/prompt/Aggregator/wrapper/addUnits.C\(\"${OUTPUTROOTFILEDIR}/${name}\"\)
+fi

--- a/rootScripts/merger/smartHadd_miniruns_dithering.sh
+++ b/rootScripts/merger/smartHadd_miniruns_dithering.sh
@@ -1,0 +1,38 @@
+#! /bin/sh
+stub=""
+if [ "$#" -ge 3 ]; then
+  stub=$3
+fi
+ROOTFILEDIR="/chafs2/work1/apar/aggRootfiles/dithering${stub}/minirun_aggregator_#_#.root"
+OUTPUTROOTFILEDIR="/chafs2/work1/apar/aggRootfiles/slugRootfiles/dithering${stub}/"
+#OUTPUTROOTFILEDIR="./"
+if [ "$#" -lt 1 ]; then
+  echo "Error: Need to pass a list file name"
+  echo "Usage: ./smartHadd_miniruns_dithering.sh list.txt (input file list, \\n separated) outputFileName (a name..., optional argument) stub (a stub argument for dithering analysis... i.e. \"_1X\")"
+else
+  IFS=$'\n' read -d '' -r -a lines < ${1}
+  # all lines
+  echo "Hadding all runs: ${lines[@]}"
+  #minirun_lines=("${lines[@]}")
+  minirun_lines=()
+  #run_lines=("${lines[@]}")
+  num_lines=0
+  num_miniruns=0
+
+  # Do miniruns
+  for i in "${!lines[@]}"; do
+  #  run_temp="${ROOTFILEDIR}/grandRootfile_${lines[$i]}/grand_aggregator.root"
+    #run_lines[$i]=$run_temp
+    num_lines=$i
+  done
+
+  slug=`rcnd ${lines[0]} slug`
+  name=minirun_slug${slug}.root
+  if [ "$#" -ge 2 ]; then
+    name=$2
+  fi
+  root -l -b -q ~/PREX/japan/rootScripts/merger/smartHadd_miniruns.C\(\"${1}\",\"${ROOTFILEDIR}\",\"${OUTPUTROOTFILEDIR}/${name}\",\"run_number\",\"minirun_n\",\"agg\"\)
+
+  # Add units
+  root -l -b -q ~/PREX/prompt/Aggregator/wrapper/addUnits.C\(\"${OUTPUTROOTFILEDIR}/${name}\"\)
+fi

--- a/rootScripts/merger/smartHadd_miniruns_regression.sh
+++ b/rootScripts/merger/smartHadd_miniruns_regression.sh
@@ -1,0 +1,34 @@
+#! /bin/sh
+ROOTFILEDIR="/chafs2/work1/apar/aggRootfiles/minirun_aggregator_#_#.root"
+OUTPUTROOTFILEDIR="/chafs2/work1/apar/aggRootfiles/slugRootfiles/"
+#OUTPUTROOTFILEDIR="./"
+if [ "$#" -lt 1 ]; then
+  echo "Error: Need to pass a list file name"
+  echo "Usage: ./smartHadd_miniruns_regression.sh list.txt (input file list, \\n separated) outputFileName (a name..., optional argument)"
+else
+  IFS=$'\n' read -d '' -r -a lines < ${1}
+  # all lines
+  echo "Hadding all runs: ${lines[@]}"
+  #minirun_lines=("${lines[@]}")
+  minirun_lines=()
+  #run_lines=("${lines[@]}")
+  num_lines=0
+  num_miniruns=0
+
+  # Do miniruns
+  for i in "${!lines[@]}"; do
+  #  run_temp="${ROOTFILEDIR}/grandRootfile_${lines[$i]}/grand_aggregator.root"
+    #run_lines[$i]=$run_temp
+    num_lines=$i
+  done
+
+  slug=`rcnd ${lines[0]} slug`
+  name=minirun_slug${slug}.root
+  if [ "$#" -ge 2 ]; then
+    name=$2
+  fi
+  root -l -b -q ~/PREX/japan/rootScripts/merger/smartHadd_miniruns.C\(\"${1}\",\"${ROOTFILEDIR}\",\"${OUTPUTROOTFILEDIR}/${name}\",\"run_number\",\"minirun_n\",\"agg\"\)
+
+  # Add units
+  root -l -b -q ~/PREX/prompt/Aggregator/wrapper/addUnits.C\(\"${OUTPUTROOTFILEDIR}/${name}\"\)
+fi

--- a/rootScripts/merger/smartHadd_slug_AT_regression.sh
+++ b/rootScripts/merger/smartHadd_slug_AT_regression.sh
@@ -1,0 +1,33 @@
+#! /bin/sh
+ROOTFILEDIR="/chafs2/work1/apar/aggRootfiles/AT/slugRootfiles/grandRootfile_#/grand_aggregator.root"
+OUTPUTROOTFILEDIR="/chafs2/work1/apar/aggRootfiles/AT/slugRootfiles/grandRootfile/"
+#OUTPUTROOTFILEDIR="./"
+if [ "$#" -lt 1 ]; then
+  echo "Error: Need to pass a list file name number \"slug##\".list"
+  echo "Usage: ./smartHadd_slug_regression.sh list.txt (input file list, \\n separated) outputFileName (a name..., optional argument)"
+else
+  IFS=$'\n' read -d '' -r -a lines < ${1}
+  # all lines
+  echo "Hadding all runs: ${lines[@]}"
+  #minirun_lines=("${lines[@]}")
+  minirun_lines=()
+  #run_lines=("${lines[@]}")
+  num_lines=0
+  num_miniruns=0
+
+  # Do miniruns
+  for i in "${!lines[@]}"; do
+  #  run_temp="${ROOTFILEDIR}/grandRootfile_${lines[$i]}/grand_aggregator.root"
+    #run_lines[$i]=$run_temp
+    num_lines=$i
+  done
+
+  name="${lines[0]}-${lines[$num_lines]}"
+  if [ "$#" -ge 2 ]; then
+    name=$2
+  fi
+  root -l -b -q ~/PREX/japan/rootScripts/merger/smartHadd.C\(\"${1}\",\"${ROOTFILEDIR}\",\"${OUTPUTROOTFILEDIR}/grand_${name}.root\",\"n_runs\",\"run_number\",\"agg\"\)
+
+  # Add units
+  root -l -b -q ~/PREX/prompt/Aggregator/wrapper/addUnits.C\(\"${OUTPUTROOTFILEDIR}/grand_${name}.root\"\)
+fi

--- a/rootScripts/merger/smartHadd_slug_burp_regression.sh
+++ b/rootScripts/merger/smartHadd_slug_burp_regression.sh
@@ -1,0 +1,33 @@
+#! /bin/sh
+ROOTFILEDIR="/chafs2/work1/apar/aggRootfiles/burp/slugRootfiles/grandRootfile_#/grand_aggregator.root"
+OUTPUTROOTFILEDIR="/chafs2/work1/apar/aggRootfiles/burp/slugRootfiles/grandRootfile/"
+#OUTPUTROOTFILEDIR="./"
+if [ "$#" -lt 1 ]; then
+  echo "Error: Need to pass a list file name number \"slug##\".list"
+  echo "Usage: ./smartHadd_slug_regression.sh list.txt (input file list, \\n separated) outputFileName (a name..., optional argument)"
+else
+  IFS=$'\n' read -d '' -r -a lines < ${1}
+  # all lines
+  echo "Hadding all runs: ${lines[@]}"
+  #minirun_lines=("${lines[@]}")
+  minirun_lines=()
+  #run_lines=("${lines[@]}")
+  num_lines=0
+  num_miniruns=0
+
+  # Do miniruns
+  for i in "${!lines[@]}"; do
+  #  run_temp="${ROOTFILEDIR}/grandRootfile_${lines[$i]}/grand_aggregator.root"
+    #run_lines[$i]=$run_temp
+    num_lines=$i
+  done
+
+  name="${lines[0]}-${lines[$num_lines]}"
+  if [ "$#" -ge 2 ]; then
+    name=$2
+  fi
+  root -l -b -q ~/PREX/japan/rootScripts/merger/smartHadd.C\(\"${1}\",\"${ROOTFILEDIR}\",\"${OUTPUTROOTFILEDIR}/grand_${name}.root\",\"n_runs\",\"run_number\",\"agg\"\)
+
+  # Add units
+  root -l -b -q ~/PREX/prompt/Aggregator/wrapper/addUnits.C\(\"${OUTPUTROOTFILEDIR}/grand_${name}.root\"\)
+fi


### PR DESCRIPTION
This should do what the commit message says.

After smoothing out all of the cuts I'm pretty sure a number of these unique cut files are redundant, but I'm leaving the segmentation as it is, even though contents match in many cases.

Has a similar thing been done for PREX for respin 2? Specifically for putting both BCMs involved in normalizing, both energy BPMs, and all ATs when applicable?