### PR TITLE
Cuts for PREX respin cleanup

### DIFF
--- a/Parity/prminput/prexCH_beamline_eventcuts.3390-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3390-.map
@@ -1,0 +1,67 @@
+!This file contains beamline event cut properties
+!*********************************************************************************************
+!Global switch to turn ON and OFF eventcut check
+!Available settings
+!***************************************************
+!To turn OFF all checks
+!EVENTCUTS = 0 
+
+!***************************************************
+!To turn OFF event cuts and perform only HW checks
+!EVENTCUTS = 1
+
+!***************************************************
+!To turn ON both event cuts and HW checks
+! EVENTCUTS = 2
+
+!***************************************************
+!To turn do both event cuts and HW checks and only flag event cut failed events
+EVENTCUTS = 3
+
+!IMPORTANT
+!---------
+!Make sure when puting tabs in the map file entries, always put ", " before inserting a tab. 
+!Otherwise the routine QwParameterFile::GetNextToken(", ") will get confuse.
+
+!Comments
+!--------
+!Devices that are not in the list are not subjected event cut checks
+!All devices  will be tested for HW checks.
+
+
+
+
+!***************************************************
+!for bcm devices
+!only upper and lower limit of the calibrated charge on the ADC HW sum. 
+!(QwVQWK_Channel::fHardwareBlockSum)
+
+!device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bcm,	bcm_an_ds,	35,	1e6,	g,	1
+
+
+
+
+!****************************************************				
+!for bpmstrpline devices
+!channel_name can be relx, rely, absx, absy, wsum, xp, xm, yp, ym
+!Cuts are applied after the VQwSubsystem::ProcessEvent() routine. 
+!So pedestals are applied before appyling the cuts.
+
+!device_type,  device_name, channel_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
+ bpmstripline,	bpm4a,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4a,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm12,	yp,	1000,	55000,	g,	0,	1000

--- a/Parity/prminput/prexCH_beamline_eventcuts.3403.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3403.map
@@ -57,6 +57,10 @@ EVENTCUTS = 3
  bpmstripline,	bpm4e,	xp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm4e,	ym,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm4e,	yp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xm,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	xp,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	ym,	1000,	55000,	g,	0,	1000
+ bpmstripline,	bpm11,	yp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	xm,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	xp,	1000,	55000,	g,	0,	1000
  bpmstripline,	bpm12,	ym,	1000,	55000,	g,	0,	1000


### PR DESCRIPTION
BPM 11 wire cut was missing from 3403.

Also, runs before 3912 lack BPM burp cuts, but the "good" cut diagnostics we saw during prompt running depended on the old version of the analyzer. So, it is worth checking if the burp cuts from 3912-> should be added to <-3912 runs.

We will also want to make sure the event cuts match the BCM normalizer (once Paul fixes that up), which will be its own ordeal of editing map files.

Other than these points everything looks fine for PREX maps, other than the quite large number of maps and our unfortunately frequent use of single-run event cut files for cleaning up noisy beam.