### PR TITLE
Updating global event cuts for PREX respin 2 to include AT detectors

### DIFF
--- a/Parity/prminput/prex_corrolator.3088.conf
+++ b/Parity/prminput/prex_corrolator.3088.conf
@@ -55,7 +55,7 @@ iv diff_bpm4aX
 iv diff_bpm4aY
 iv diff_bpm4eX
 iv diff_bpm4eY
-iv diff_bpm12X
+iv diff_bpmE
 #iv asym_qwk_0_4
 
 treetype Hel_Tree

--- a/Parity/prminput/prex_corrolator.3089-.conf
+++ b/Parity/prminput/prex_corrolator.3089-.conf
@@ -55,7 +55,7 @@ iv diff_bpm4aX
 iv diff_bpm4aY
 iv diff_bpm4eX
 iv diff_bpm4eY
-iv diff_bpm12X
+iv diff_bpmE
 #iv asym_qwk_0_4
 
 treetype Hel_Tree

--- a/Parity/prminput/prex_corrolator.3130-.conf
+++ b/Parity/prminput/prex_corrolator.3130-.conf
@@ -23,6 +23,6 @@ iv diff_bpm4aX
 iv diff_bpm4aY
 iv diff_bpm4eX
 iv diff_bpm4eY
-iv diff_bpm12X
+iv diff_bpmE
 
 treetype Hel_Tree

--- a/Parity/prminput/prex_corrolator.3583-.conf
+++ b/Parity/prminput/prex_corrolator.3583-.conf
@@ -25,6 +25,6 @@ iv diff_bpm4aX
 iv diff_bpm4aY
 iv diff_bpm4eX
 iv diff_bpm4eY
-iv diff_bpm11X
+iv diff_bpmE
 
 treetype Hel_Tree

--- a/Parity/prminput/prex_corrolator.3803-.conf
+++ b/Parity/prminput/prex_corrolator.3803-.conf
@@ -1,0 +1,49 @@
+# configuration for linRegblue ( must end with nonempty 'regvars/treetype'  block )
+#inpPath /home/cdaq/qweak/qwScratch/rootfiles/qwPass1_   : on cdaql5
+# inpPath  /home/MRVallee/japan/isu_sample_  :  pass3 production
+# customcut  jancut1 yield_bcm_ds.hw_sum>0
+# minEvents  1000
+
+# dependent and Independent variables for Regression (arbitrary order)
+# regvars blahblah
+dv asym_usl
+dv asym_dsl
+dv asym_usr
+dv asym_dsr
+dv asym_us_avg
+dv asym_us_dd
+dv asym_ds_avg
+dv asym_ds_dd
+dv asym_left_avg
+dv asym_left_dd
+dv asym_right_avg
+dv asym_right_dd
+
+dv asym_atl1
+dv asym_atl2
+dv asym_atr1
+dv asym_atr2
+dv asym_atl_avg
+dv asym_atl_dd
+dv asym_atr_avg
+dv asym_atr_dd
+dv asym_at1_avg
+dv asym_at1_dd
+dv asym_at2_avg
+dv asym_at2_dd
+dv asym_atl_dd_atr_dd_avg
+dv asym_atl_dd_atr_dd_dd
+dv asym_atr1l2_avg
+dv asym_atr1l2_dd
+dv asym_atl1r2_avg
+dv asym_atl1r2_dd
+
+#----- IVs -----
+## Slugs 12- are these:
+iv diff_bpm4aX
+iv diff_bpm4aY
+iv diff_bpm4eX
+iv diff_bpm4eY
+iv diff_bpm11X
+
+treetype Hel_Tree

--- a/Parity/prminput/prex_corrolator.3803-.conf
+++ b/Parity/prminput/prex_corrolator.3803-.conf
@@ -44,6 +44,6 @@ iv diff_bpm4aX
 iv diff_bpm4aY
 iv diff_bpm4eX
 iv diff_bpm4eY
-iv diff_bpm11X
+iv diff_bpmE
 
 treetype Hel_Tree

--- a/Parity/prminput/prex_corrolator.3884-3893.conf
+++ b/Parity/prminput/prex_corrolator.3884-3893.conf
@@ -1,0 +1,27 @@
+# configuration for linRegblue ( must end with nonempty 'regvars/treetype'  block )
+#inpPath /home/cdaq/qweak/qwScratch/rootfiles/qwPass1_   : on cdaql5
+# inpPath  /home/MRVallee/japan/isu_sample_  :  pass3 production
+# customcut  jancut1 yield_bcm_ds.hw_sum>0
+# minEvents  1000
+
+# dependent and Independent variables for Regression (arbitrary order)
+# regvars blahblah
+dv asym_usl
+dv asym_dsl
+dv asym_left_avg
+dv asym_left_dd
+
+dv asym_atl1
+dv asym_atl2
+dv asym_atl_avg
+dv asym_atl_dd
+
+#----- IVs -----
+## Slugs 12- are these:
+iv diff_bpm4aX
+iv diff_bpm4aY
+iv diff_bpm4eX
+iv diff_bpm4eY
+iv diff_bpmE
+
+treetype Hel_Tree

--- a/Parity/prminput/prex_corrolator.4708-4939.conf
+++ b/Parity/prminput/prex_corrolator.4708-4939.conf
@@ -1,0 +1,32 @@
+# configuration for linRegblue ( must end with nonempty 'regvars/treetype'  block )
+#inpPath /home/cdaq/qweak/qwScratch/rootfiles/qwPass1_   : on cdaql5
+# inpPath  /home/MRVallee/japan/isu_sample_  :  pass3 production
+# customcut  jancut1 yield_bcm_ds.hw_sum>0
+# minEvents  1000
+
+# dependent and Independent variables for Regression (arbitrary order)
+# regvars blahblah
+dv asym_usl
+dv asym_dsl
+dv asym_usr
+dv asym_dsr
+dv asym_us_avg
+dv asym_us_dd
+dv asym_ds_avg
+dv asym_ds_dd
+dv asym_left_avg
+dv asym_left_dd
+dv asym_right_avg
+dv asym_right_dd
+
+# ATs blinded
+
+#----- IVs -----
+## Slugs 12- are these:
+iv diff_bpm4aX
+iv diff_bpm4aY
+iv diff_bpm4eX
+iv diff_bpm4eY
+iv diff_bpm11X
+
+treetype Hel_Tree

--- a/Parity/prminput/prex_corrolator.4708-4939.conf
+++ b/Parity/prminput/prex_corrolator.4708-4939.conf
@@ -27,6 +27,6 @@ iv diff_bpm4aX
 iv diff_bpm4aY
 iv diff_bpm4eX
 iv diff_bpm4eY
-iv diff_bpm11X
+iv diff_bpmE
 
 treetype Hel_Tree

--- a/Parity/prminput/prex_corrolator_all.3130-3389.conf
+++ b/Parity/prminput/prex_corrolator_all.3130-3389.conf
@@ -16,17 +16,12 @@ iv diff_bpm4aX
 iv diff_bpm4aY
 iv diff_bpm4eX
 iv diff_bpm4eY
-iv diff_bpm4aesumX
-iv diff_bpm4aesumY
-iv diff_bpm4aediffX
-iv diff_bpm4aediffY
 iv diff_bpm1X
 iv diff_bpm1Y
 iv diff_bpm8X
 iv diff_bpm8Y
 iv diff_bpm12X
 iv diff_bpm12Y
-iv diff_bpmE
 iv diff_cav4cX
 iv diff_cav4cY
 

--- a/Parity/prminput/prex_corrolator_all.3130-3389.conf
+++ b/Parity/prminput/prex_corrolator_all.3130-3389.conf
@@ -16,12 +16,17 @@ iv diff_bpm4aX
 iv diff_bpm4aY
 iv diff_bpm4eX
 iv diff_bpm4eY
+iv diff_bpm4aesumX
+iv diff_bpm4aesumY
+iv diff_bpm4aediffX
+iv diff_bpm4aediffY
 iv diff_bpm1X
 iv diff_bpm1Y
 iv diff_bpm8X
 iv diff_bpm8Y
 iv diff_bpm12X
 iv diff_bpm12Y
+iv diff_bpmE
 iv diff_cav4cX
 iv diff_cav4cY
 

--- a/Parity/prminput/prex_corrolator_all.3390-.conf
+++ b/Parity/prminput/prex_corrolator_all.3390-.conf
@@ -17,17 +17,12 @@ iv diff_bpm4aX
 iv diff_bpm4aY
 iv diff_bpm4eX
 iv diff_bpm4eY
-iv diff_bpm4aesumX
-iv diff_bpm4aesumY
-iv diff_bpm4aediffX
-iv diff_bpm4aediffY
 iv diff_bpm1X
 iv diff_bpm1Y
 iv diff_bpm11X
 iv diff_bpm11Y
 iv diff_bpm12X
 iv diff_bpm12Y
-iv diff_bpmE
 iv diff_bpm16X
 iv diff_bpm16Y
 iv diff_cav4cX

--- a/Parity/prminput/prex_corrolator_all.3390-.conf
+++ b/Parity/prminput/prex_corrolator_all.3390-.conf
@@ -17,12 +17,17 @@ iv diff_bpm4aX
 iv diff_bpm4aY
 iv diff_bpm4eX
 iv diff_bpm4eY
+iv diff_bpm4aesumX
+iv diff_bpm4aesumY
+iv diff_bpm4aediffX
+iv diff_bpm4aediffY
 iv diff_bpm1X
 iv diff_bpm1Y
 iv diff_bpm11X
 iv diff_bpm11Y
 iv diff_bpm12X
 iv diff_bpm12Y
+iv diff_bpmE
 iv diff_bpm16X
 iv diff_bpm16Y
 iv diff_cav4cX

--- a/Parity/prminput/prex_corrolator_all.3803-.conf
+++ b/Parity/prminput/prex_corrolator_all.3803-.conf
@@ -12,6 +12,25 @@ dv asym_left_dd
 dv asym_right_avg
 dv asym_right_dd
 
+dv asym_atl1
+dv asym_atl2
+dv asym_atr1
+dv asym_atr2
+dv asym_atl_avg
+dv asym_atl_dd
+dv asym_atr_avg
+dv asym_atr_dd
+dv asym_at1_avg
+dv asym_at1_dd
+dv asym_at2_avg
+dv asym_at2_dd
+dv asym_atl1r2_avg
+dv asym_atl1r2_dd
+dv asym_atr1l2_avg
+dv asym_atr1l2_dd
+dv asym_atl_dd_atr_dd_avg
+dv asym_atl_dd_atr_dd_dd
+
 #----- IVs -----
 iv diff_bpm4aX
 iv diff_bpm4aY

--- a/Parity/prminput/prex_corrolator_all.3803-.conf
+++ b/Parity/prminput/prex_corrolator_all.3803-.conf
@@ -36,12 +36,17 @@ iv diff_bpm4aX
 iv diff_bpm4aY
 iv diff_bpm4eX
 iv diff_bpm4eY
+iv diff_bpm4aesumX
+iv diff_bpm4aesumY
+iv diff_bpm4aediffX
+iv diff_bpm4aediffY
 iv diff_bpm1X
 iv diff_bpm1Y
 iv diff_bpm11X
 iv diff_bpm11Y
 iv diff_bpm12X
 iv diff_bpm12Y
+iv diff_bpmE
 iv diff_bpm16X
 iv diff_bpm16Y
 iv diff_cav4cX

--- a/Parity/prminput/prex_corrolator_all.3803-.conf
+++ b/Parity/prminput/prex_corrolator_all.3803-.conf
@@ -36,17 +36,12 @@ iv diff_bpm4aX
 iv diff_bpm4aY
 iv diff_bpm4eX
 iv diff_bpm4eY
-iv diff_bpm4aesumX
-iv diff_bpm4aesumY
-iv diff_bpm4aediffX
-iv diff_bpm4aediffY
 iv diff_bpm1X
 iv diff_bpm1Y
 iv diff_bpm11X
 iv diff_bpm11Y
 iv diff_bpm12X
 iv diff_bpm12Y
-iv diff_bpmE
 iv diff_bpm16X
 iv diff_bpm16Y
 iv diff_cav4cX

--- a/Parity/prminput/prex_corrolator_all.3884-3893.conf
+++ b/Parity/prminput/prex_corrolator_all.3884-3893.conf
@@ -1,0 +1,33 @@
+# dependent and Independent variables for Regression (arbitrary order)
+dv asym_usl
+dv asym_dsl
+dv asym_left_avg
+dv asym_left_dd
+
+dv asym_atl1
+dv asym_atl2
+dv asym_atl_avg
+dv asym_atl_dd
+
+#----- IVs -----
+iv diff_bpm4aX
+iv diff_bpm4aY
+iv diff_bpm4eX
+iv diff_bpm4eY
+iv diff_bpm4aesumX
+iv diff_bpm4aesumY
+iv diff_bpm4aediffX
+iv diff_bpm4aediffY
+iv diff_bpm1X
+iv diff_bpm1Y
+iv diff_bpm11X
+iv diff_bpm11Y
+iv diff_bpm12X
+iv diff_bpm12Y
+iv diff_bpmE
+iv diff_bpm16X
+iv diff_bpm16Y
+iv diff_cav4cX
+iv diff_cav4cY
+
+treetype Hel_Tree

--- a/Parity/prminput/prex_corrolator_all.3884-3893.conf
+++ b/Parity/prminput/prex_corrolator_all.3884-3893.conf
@@ -14,17 +14,12 @@ iv diff_bpm4aX
 iv diff_bpm4aY
 iv diff_bpm4eX
 iv diff_bpm4eY
-iv diff_bpm4aesumX
-iv diff_bpm4aesumY
-iv diff_bpm4aediffX
-iv diff_bpm4aediffY
 iv diff_bpm1X
 iv diff_bpm1Y
 iv diff_bpm11X
 iv diff_bpm11Y
 iv diff_bpm12X
 iv diff_bpm12Y
-iv diff_bpmE
 iv diff_bpm16X
 iv diff_bpm16Y
 iv diff_cav4cX

--- a/Parity/prminput/prex_corrolator_all.4708-4939.conf
+++ b/Parity/prminput/prex_corrolator_all.4708-4939.conf
@@ -19,12 +19,17 @@ iv diff_bpm4aX
 iv diff_bpm4aY
 iv diff_bpm4eX
 iv diff_bpm4eY
+iv diff_bpm4aesumX
+iv diff_bpm4aesumY
+iv diff_bpm4aediffX
+iv diff_bpm4aediffY
 iv diff_bpm1X
 iv diff_bpm1Y
 iv diff_bpm11X
 iv diff_bpm11Y
 iv diff_bpm12X
 iv diff_bpm12Y
+iv diff_bpmE
 iv diff_bpm16X
 iv diff_bpm16Y
 iv diff_cav4cX

--- a/Parity/prminput/prex_corrolator_all.4708-4939.conf
+++ b/Parity/prminput/prex_corrolator_all.4708-4939.conf
@@ -12,6 +12,8 @@ dv asym_left_dd
 dv asym_right_avg
 dv asym_right_dd
 
+# No ATs, blinded
+
 #----- IVs -----
 iv diff_bpm4aX
 iv diff_bpm4aY

--- a/Parity/prminput/prex_corrolator_all.4708-4939.conf
+++ b/Parity/prminput/prex_corrolator_all.4708-4939.conf
@@ -19,17 +19,12 @@ iv diff_bpm4aX
 iv diff_bpm4aY
 iv diff_bpm4eX
 iv diff_bpm4eY
-iv diff_bpm4aesumX
-iv diff_bpm4aesumY
-iv diff_bpm4aediffX
-iv diff_bpm4aediffY
 iv diff_bpm1X
 iv diff_bpm1Y
 iv diff_bpm11X
 iv diff_bpm11Y
 iv diff_bpm12X
 iv diff_bpm12Y
-iv diff_bpmE
 iv diff_bpm16X
 iv diff_bpm16Y
 iv diff_cav4cX

--- a/Parity/prminput/prex_corrolator_alldet.3130-.conf
+++ b/Parity/prminput/prex_corrolator_alldet.3130-.conf
@@ -40,6 +40,6 @@ iv diff_bpm4aX
 iv diff_bpm4aY
 iv diff_bpm4eX
 iv diff_bpm4eY
-iv diff_bpm12X
+iv diff_bpmE
 
 treetype Hel_Tree

--- a/Parity/prminput/prex_corrolator_alldet.3390-.conf
+++ b/Parity/prminput/prex_corrolator_alldet.3390-.conf
@@ -40,6 +40,6 @@ iv diff_bpm4aX
 iv diff_bpm4aY
 iv diff_bpm4eX
 iv diff_bpm4eY
-iv diff_bpm12X
+iv diff_bpmE
 
 treetype Hel_Tree

--- a/Parity/prminput/prex_corrolator_alldet.3583-.conf
+++ b/Parity/prminput/prex_corrolator_alldet.3583-.conf
@@ -31,6 +31,6 @@ iv diff_bpm4aX
 iv diff_bpm4aY
 iv diff_bpm4eX
 iv diff_bpm4eY
-iv diff_bpm11X
+iv diff_bpmE
 
 treetype Hel_Tree

--- a/Parity/prminput/prex_corrolator_alldet.3803-.conf
+++ b/Parity/prminput/prex_corrolator_alldet.3803-.conf
@@ -53,6 +53,6 @@ iv diff_bpm4aX
 iv diff_bpm4aY
 iv diff_bpm4eX
 iv diff_bpm4eY
-iv diff_bpm11X
+iv diff_bpmE
 
 treetype Hel_Tree

--- a/Parity/prminput/prex_corrolator_alldet.3884-3893.conf
+++ b/Parity/prminput/prex_corrolator_alldet.3884-3893.conf
@@ -1,0 +1,20 @@
+# dependent and Independent variables for Regression (arbitrary order)
+# regvars blahblah
+
+dv asym_atl1
+dv asym_atl2
+dv asym_atl_avg
+dv asym_atl_dd
+
+dv asym_usl
+dv asym_dsl
+dv asym_left_avg
+dv asym_left_dd
+#----- IVs -----
+iv diff_bpm4aX
+iv diff_bpm4aY
+iv diff_bpm4eX
+iv diff_bpm4eY
+iv diff_bpm11X
+
+treetype Hel_Tree

--- a/Parity/prminput/prex_corrolator_alldet.3884-3893.conf
+++ b/Parity/prminput/prex_corrolator_alldet.3884-3893.conf
@@ -15,6 +15,6 @@ iv diff_bpm4aX
 iv diff_bpm4aY
 iv diff_bpm4eX
 iv diff_bpm4eY
-iv diff_bpm11X
+iv diff_bpmE
 
 treetype Hel_Tree

--- a/Parity/prminput/prex_corrolator_alldet.4708-4939.conf
+++ b/Parity/prminput/prex_corrolator_alldet.4708-4939.conf
@@ -36,6 +36,6 @@ iv diff_bpm4aX
 iv diff_bpm4aY
 iv diff_bpm4eX
 iv diff_bpm4eY
-iv diff_bpm11X
+iv diff_bpmE
 
 treetype Hel_Tree

--- a/Parity/prminput/prex_corrolator_alldet.4708-4939.conf
+++ b/Parity/prminput/prex_corrolator_alldet.4708-4939.conf
@@ -1,7 +1,27 @@
 # dependent and Independent variables for Regression (arbitrary order)
+# regvars blahblah
+dv asym_sam1
+dv asym_sam2
+dv asym_sam3
+dv asym_sam4
+dv asym_sam5
+dv asym_sam6
+dv asym_sam7
+dv asym_sam8
+dv asym_sam_15_avg
+dv asym_sam_15_dd
+dv asym_sam_37_avg
+dv asym_sam_37_dd
+dv asym_sam_26_avg
+dv asym_sam_26_dd
+dv asym_sam_48_avg
+dv asym_sam_48_dd
+
+# ATs blinded
+#
 dv asym_usl
-dv asym_usr
 dv asym_dsl
+dv asym_usr
 dv asym_dsr
 dv asym_us_avg
 dv asym_us_dd
@@ -11,21 +31,11 @@ dv asym_left_avg
 dv asym_left_dd
 dv asym_right_avg
 dv asym_right_dd
-
 #----- IVs -----
 iv diff_bpm4aX
 iv diff_bpm4aY
 iv diff_bpm4eX
 iv diff_bpm4eY
-iv diff_bpm1X
-iv diff_bpm1Y
 iv diff_bpm11X
-iv diff_bpm11Y
-iv diff_bpm12X
-iv diff_bpm12Y
-iv diff_bpm16X
-iv diff_bpm16Y
-iv diff_cav4cX
-iv diff_cav4cY
 
 treetype Hel_Tree

--- a/Parity/prminput/prex_maindet_eventcuts.3803-.map
+++ b/Parity/prminput/prex_maindet_eventcuts.3803-.map
@@ -6,7 +6,7 @@ IntegrationPMT, dsl,		-100000,	100000,	g,	0
 IntegrationPMT, usr,		-100000,	100000,	g,	0
 IntegrationPMT, dsr,		-100000,	100000,	g,	0
 
-IntegrationPMT, atl1,		-100000,	120000,	l,	0
-IntegrationPMT, atl2,		-100000,	120000,	l,	0
-IntegrationPMT, atr1,		-100000,	120000,	l,	0
-IntegrationPMT, atr2,		-100000,	120000,	l,	0
+IntegrationPMT, atl1,		-100000,	120000,	g,	0
+IntegrationPMT, atl2,		-100000,	120000,	g,	0
+IntegrationPMT, atr1,		-100000,	120000,	g,	0
+IntegrationPMT, atr2,		-100000,	120000,	g,	0

--- a/Parity/prminput/prex_maindet_eventcuts.3884-3893.map
+++ b/Parity/prminput/prex_maindet_eventcuts.3884-3893.map
@@ -1,5 +1,4 @@
-! For runs 3564 and 3565 (HV off left, Quads off Right) - want to local cut the main RHRS detectors, global cut the main LHRS detectors
-! left arm running of slug 31
+! RHRS DAQ broke for a while
 
 EVENTCUTS = 3
 IntegrationPMT, usl,	-1000,	100000,	g,	0

--- a/Parity/prminput/prex_maindet_eventcuts.3884-3893.map
+++ b/Parity/prminput/prex_maindet_eventcuts.3884-3893.map
@@ -6,3 +6,8 @@ IntegrationPMT, usl,	-1000,	100000,	g,	0
 IntegrationPMT, dsl,	-1000,	100000,	g,	0
 IntegrationPMT, usr,	-1000,	100000,	l,	0
 IntegrationPMT, dsr,	-1000,	100000,	l,	0
+
+IntegrationPMT, atl1,		-100000,	120000,	g,	0
+IntegrationPMT, atl2,		-100000,	120000,	g,	0
+IntegrationPMT, atr1,		-100000,	120000,	l,	0
+IntegrationPMT, atr2,		-100000,	120000,	l,	0

--- a/Parity/prminput/prex_maindet_eventcuts.4074-4077.map
+++ b/Parity/prminput/prex_maindet_eventcuts.4074-4077.map
@@ -7,7 +7,7 @@ IntegrationPMT, dsl,		-1000,	100000,	g,	0
 IntegrationPMT, usr,		-100001,	-100000,	l,	0
 IntegrationPMT, dsr,		-100001,	-100000,	l,	0
 
-IntegrationPMT, atl1,		-1000,	120000,	l,	0
-IntegrationPMT, atl2,		-1000,	120000,	l,	0
+IntegrationPMT, atl1,		-1000,	120000,	g,	0
+IntegrationPMT, atl2,		-1000,	120000,	g,	0
 IntegrationPMT, atr1,		-100001,	-100000,	l,	0
 IntegrationPMT, atr2,		-100001,	-100000,	l,	0

--- a/Parity/prminput/prex_maindet_eventcuts.4679-4690.map
+++ b/Parity/prminput/prex_maindet_eventcuts.4679-4690.map
@@ -7,8 +7,8 @@ IntegrationPMT, dsl,		-1000,	100000,	g,	0
 IntegrationPMT, usr,		-1000,	100000,	l,	0
 IntegrationPMT, dsr,		-1000,	100000,	l,	0
 
-IntegrationPMT, atl1,		-1000,	120000,	l,	0
-IntegrationPMT, atl2,		-1000,	120000,	l,	0
+IntegrationPMT, atl1,		-1000,	120000,	g,	0
+IntegrationPMT, atl2,		-1000,	120000,	g,	0
 IntegrationPMT, atr1,		-1000,	120000,	l,	0
 IntegrationPMT, atr2,		-1000,	120000,	l,	0
 


### PR DESCRIPTION
Start caring about ATs, prior runs are often saturated - prex_maindet_eventcuts.3803-.map
Left arm only running - prex_maindet_eventcuts.3884-3893.map
Left arm only running - prex_maindet_eventcuts.4074-4077.map
Left arm only running - prex_maindet_eventcuts.4679-4690.map
ATs hardware blinded  - prex_maindet_eventcuts.4708-4939.map

All per Devi