### PR TITLE
Bugfix datahandlers fail connecting ivs

### DIFF
--- a/Parity/src/QwBlindDetectorArray.cc
+++ b/Parity/src/QwBlindDetectorArray.cc
@@ -162,7 +162,7 @@ Bool_t QwBlindDetectorArray::PublishByRequest(TString device_name)
     break;
   }
   if (!status)  
-    QwError << "QwBlindDetectorArray::PublishByRequest:  Failed to publish channel name:  " << device_name << QwLog::endl;
+    QwDebug << "QwBlindDetectorArray::PublishByRequest:  Failed to publish channel name:  " << device_name << QwLog::endl;
   return status;
 }
 

--- a/Parity/src/QwCombiner.cc
+++ b/Parity/src/QwCombiner.cc
@@ -204,7 +204,9 @@ Int_t QwCombiner::ConnectChannels(
     } else if(fDependentName.at(dv).at(0) == '@' ){
         name = fDependentName.at(dv).substr(1,fDependentName.at(dv).length());
     }else{
-      switch (fDependentType.at(dv)) {
+      dv_ptr = this->RequestExternalPointer(fDependentFull.at(dv));
+      if (dv_ptr==NULL){
+	switch (fDependentType.at(dv)) {
         case kHandleTypeAsym:
           dv_ptr = asym.RequestExternalPointer(fDependentName.at(dv));
           break;
@@ -217,6 +219,7 @@ Int_t QwCombiner::ConnectChannels(
 		                << ", for asym/diff combiner does not have proper type, type=="
 		                << fDependentType.at(dv) << "."<< QwLog::endl;
           break;
+	}
       }
 
       vqwk = dynamic_cast<const QwVQWK_Channel*>(dv_ptr);
@@ -255,7 +258,9 @@ Int_t QwCombiner::ConnectChannels(
     for (size_t iv = 0; iv < fIndependentName.at(dv).size(); iv++) {
       // Get the independent variables
       const VQwHardwareChannel* iv_ptr = 0;
-      switch (fIndependentType.at(dv).at(iv)) {
+      iv_ptr = RequestExternalPointer(fIndependentName.at(dv).at(iv));
+      if (iv_ptr == NULL){
+	switch (fIndependentType.at(dv).at(iv)) {
         case kHandleTypeAsym:
           iv_ptr = asym.RequestExternalPointer(fIndependentName.at(dv).at(iv));
           break;
@@ -266,9 +271,7 @@ Int_t QwCombiner::ConnectChannels(
           QwWarning << "Independent variable for combiner has unknown type."
                     << QwLog::endl;
           break;
-      }
-      if (iv_ptr == NULL){
-        iv_ptr = RequestExternalPointer(fIndependentName.at(dv).at(iv));
+	}
       }
       if (iv_ptr) {
         //QwMessage << " iv: " << fIndependentName.at(dv).at(iv) << " (sens = " << fSensitivity.at(dv).at(iv) << ")" << QwLog::endl;

--- a/Parity/src/QwCorrelator.cc
+++ b/Parity/src/QwCorrelator.cc
@@ -355,7 +355,9 @@ Int_t QwCorrelator::ConnectChannels(QwSubsystemArrayParity& asym, QwSubsystemArr
   for (size_t iv = 0; iv < fIndependentName.size(); iv++) {
     // Get the independent variables
     const VQwHardwareChannel* iv_ptr = 0;
-    switch (fIndependentType.at(iv)) {
+    iv_ptr = this->RequestExternalPointer(fIndependentFull.at(iv));
+    if (iv_ptr==NULL){
+      switch (fIndependentType.at(iv)) {
       case kHandleTypeAsym:
         iv_ptr = asym.RequestExternalPointer(fIndependentName.at(iv));
         break;
@@ -366,6 +368,7 @@ Int_t QwCorrelator::ConnectChannels(QwSubsystemArrayParity& asym, QwSubsystemArr
         QwWarning << "Independent variable for correlator has unknown type."
                   << QwLog::endl;
         break;
+      }
     }
     if (iv_ptr) {
       fIndependentVar.push_back(iv_ptr);

--- a/Parity/src/QwDetectorArray.cc
+++ b/Parity/src/QwDetectorArray.cc
@@ -162,7 +162,7 @@ Bool_t QwDetectorArray::PublishByRequest(TString device_name)
     break;
   }
   if (!status)  
-    QwError << "QwDetectorArray::PublishByRequest:  Failed to publish channel name:  " << device_name << QwLog::endl;
+    QwDebug << "QwDetectorArray::PublishByRequest:  Failed to publish channel name:  " << device_name << QwLog::endl;
   return status;
 }
 


### PR DESCRIPTION
Resolves a bug that data handlers are not able to request IV's from previously defined data handlers (DV's had been request-able already), and removes extraneous error messages during the data element request process for the detector array classes.

This will resolve issues #296 and #271 for the develop branch.