### PR TITLE
Changed the global BCM cuts to use "bcm_target" for PREX2.

### DIFF
--- a/Parity/prminput/prexCH_beamline_eventcuts.2904-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.2904-.map
@@ -27,7 +27,7 @@ EVENTCUTS = 3
 !***************************************************
 !for bcm devices
 !device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability percentage
- bcm, bcm_an_ds3,		20,	1e6,	g,	0.8
+ combinedbcm, bcm_target,		20,	1e6,	g,	0.8
 
 !for parity mock data run 1000 9.98608e+06
 !bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 

--- a/Parity/prminput/prexCH_beamline_eventcuts.2935.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.2935.map
@@ -27,7 +27,7 @@ EVENTCUTS = 3
 !***************************************************
 !for bcm devices
 !device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability percentage
- bcm, bcm_an_ds3,		0,	1e6,	g,	0.8
+ combinedbcm, bcm_target,		0,	1e6,	g,	0.8
 
 !for parity mock data run 1000 9.98608e+06
 !bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 

--- a/Parity/prminput/prexCH_beamline_eventcuts.2936-2947.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.2936-2947.map
@@ -27,7 +27,7 @@ EVENTCUTS = 3
 !***************************************************
 !for bcm devices
 !device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability percentage
- bcm, bcm_an_ds3,		5,	1e6,	g,	0.8
+ combinedbcm, bcm_target,		5,	1e6,	g,	0.8
 
 !for parity mock data run 1000 9.98608e+06
 !bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 

--- a/Parity/prminput/prexCH_beamline_eventcuts.2968.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.2968.map
@@ -27,7 +27,7 @@ EVENTCUTS = 3
 !***************************************************
 !for bcm devices
 !device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability percentage
- bcm, bcm_an_ds3,		3,	1e6,	g,	0.8
+ combinedbcm, bcm_target,		3,	1e6,	g,	0.8
 
 !for parity mock data run 1000 9.98608e+06
 !bcm, qwk_bcm0l03, 	8.00e+06, 	1.20e+07, 1, 0 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3114.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3114.map
@@ -27,7 +27,7 @@ EVENTCUTS = 3
 !***************************************************
 !for bcm devices
 !device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability percentage
- bcm, bcm_an_ds3,		3,	1e6,	g,	0.8
+ combinedbcm, bcm_target,		3,	1e6,	g,	0.8
  bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
  bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
  bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000

--- a/Parity/prminput/prexCH_beamline_eventcuts.3139.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3139.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds,	35,	1e6,	g,	1
+ combinedbcm, bcm_target,	35,	1e6,	g,	1
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3140.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3140.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds,	35,	1e6,	g,	1
+ combinedbcm, bcm_target,	35,	1e6,	g,	1
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3146.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3146.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds,	35,	1e6,	g,	1.2
+ combinedbcm, bcm_target,	35,	1e6,	g,	1.2
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3289-3292.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3289-3292.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds,	35,	1e6,	g,	1.2
+ combinedbcm, bcm_target,	35,	1e6,	g,	1.2
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3390-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3390-.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds,	35,	1e6,	g,	1
+ combinedbcm, bcm_target,	35,	1e6,	g,	1
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3403.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3403.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds,	35,	1e6,	g,	1
+ combinedbcm, bcm_target,	35,	1e6,	g,	1
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3404-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3404-.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds,	35,	1e6,	g,	1
+ combinedbcm,	bcm_target,	35,	1e6,	g,	1
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3420.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3420.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds,	35,	1e6,	g,	1
+ combinedbcm, bcm_target,	35,	1e6,	g,	1
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3424.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3424.map
@@ -27,7 +27,7 @@ EVENTCUTS = 3
 !***************************************************
 !for bcm devices
 !device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability percentage
- bcm, bcm_an_ds3,		55,	1e6,	g,	0.8
+ combinedbcm, bcm_target,		55,	1e6,	g,	0.8
  bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
  bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
  bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000

--- a/Parity/prminput/prexCH_beamline_eventcuts.3425-3428.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3425-3428.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds,	55,	1e6,	g,	1.4
+ combinedbcm, bcm_target,	55,	1e6,	g,	1.4
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3429.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3429.map
@@ -27,7 +27,7 @@ EVENTCUTS = 3
 !***************************************************
 !for bcm devices
 !device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability percentage
- bcm, bcm_an_ds3,		55,	1e6,	g,	0.8
+ combinedbcm, bcm_target,		55,	1e6,	g,	0.8
  bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
  bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
  bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000

--- a/Parity/prminput/prexCH_beamline_eventcuts.3430.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3430.map
@@ -27,7 +27,7 @@ EVENTCUTS = 3
 !***************************************************
 !for bcm devices
 !device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability percentage
- bcm, bcm_an_ds3,		55,	1e6,	g,	0.8
+ combinedbcm, bcm_target,		55,	1e6,	g,	0.8
  bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
  bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
  bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000

--- a/Parity/prminput/prexCH_beamline_eventcuts.3450-3452.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3450-3452.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds,	35,	1e6,	g,	1
+ combinedbcm, bcm_target,	35,	1e6,	g,	1
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3453-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3453-.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds,	35,	1e6,	g,	1
+ combinedbcm, bcm_target,	35,	1e6,	g,	1
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3455.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3455.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds,	35,	1e6,	g,	1
+ combinedbcm, bcm_target,	35,	1e6,	g,	1
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3489.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3489.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds,	35,	1e6,	g,	1
+ combinedbcm, bcm_target,	35,	1e6,	g,	1
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3524.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3524.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds,	35,	1e6,	g,	1
+ combinedbcm, bcm_target,	35,	1e6,	g,	1
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3540.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3540.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds,	35,	1e6,	g,	1
+ combinedbcm, bcm_target,	35,	1e6,	g,	1
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3548.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3548.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds,	35,	1e6,	g,	1
+ combinedbcm, bcm_target,	35,	1e6,	g,	1
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3566-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3566-.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_ds,	35,	1e6,	g,	1
+ combinedbcm, bcm_target,	35,	1e6,	g,	1
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3583-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3583-.map
@@ -30,7 +30,7 @@ EVENTCUTS = 3
 ! 70 uA running BCM, BPM tracking non-saturation, global promotion of device error codes, BPM 4aYM had a few runs with strange wire response due to poor BNC connection
 ! So far stability cut on bcm_an_ds was 0.8. As we decided in WAC meeting 07/24/2019, we make the cut 1.4 for 70uA and 1 for 50uA running. i.e 2% stability cut. - Also changing to DG ds to mitigate noise
  !bcm, bcm_an_ds,		35,	1e6,	g,	1.4
- bcm, bcm_dg_ds,		35,	1e6,	g,	1.4
+ combinedbcm, bcm_target,		35,	1e6,	g,	1.4
 ! Adding the upstream BCM too, mostly for verification that it has no hardware errors and that it is also seeing the same beam
  !bcm, bcm_an_us,		5,	1e6,	g, 0
  bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000

--- a/Parity/prminput/prexCH_beamline_eventcuts.3595-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3595-.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+ combinedbcm, bcm_target,	55,	1e6,	g,	1.4
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3622-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3622-.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+ combinedbcm, bcm_target,	55,	1e6,	g,	1.4
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3633-3636.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3633-3636.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_dg_ds,	45,	1e6,	g,	1.2
+ combinedbcm, bcm_target,	45,	1e6,	g,	1.2
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3821.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3821.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_dg_ds,	45,	1e6,	g,	1.2
+ combinedbcm, bcm_target,	45,	1e6,	g,	1.2
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3853.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3853.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+ combinedbcm, bcm_target,	55,	1e6,	g,	1.4
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.3912-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.3912-.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_us,	55,	1e6,	g,	1.4
+ combinedbcm, bcm_target,	55,	1e6,	g,	1.4
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.4169.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4169.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_us,	55,	1e6,	g,	1.4
+ combinedbcm, bcm_target,	55,	1e6,	g,	1.4
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.4224.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4224.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_an_us,	55,	1e6,	g,	1.4
+ combinedbcm, bcm_target,	55,	1e6,	g,	1.4
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.4257-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4257-.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+ combinedbcm, bcm_target,	55,	1e6,	g,	1.4
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.4396.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4396.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+ combinedbcm, bcm_target,	55,	1e6,	g,	1.4
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.4439-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4439-.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+ combinedbcm, bcm_target,	55,	1e6,	g,	1.4
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.4472.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4472.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+ combinedbcm, bcm_target,	55,	1e6,	g,	1.4
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.4481-4482.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4481-4482.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+ combinedbcm, bcm_target,	55,	1e6,	g,	1.4
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.4481.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4481.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+ combinedbcm, bcm_target,	55,	1e6,	g,	1.4
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.4491.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4491.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+ combinedbcm, bcm_target,	55,	1e6,	g,	1.4
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.4498.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4498.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+ combinedbcm, bcm_target,	55,	1e6,	g,	1.4
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.4503.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4503.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+ combinedbcm, bcm_target,	55,	1e6,	g,	1.4
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.4512.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4512.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+ combinedbcm, bcm_target,	55,	1e6,	g,	1.4
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.4514.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4514.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+ combinedbcm, bcm_target,	55,	1e6,	g,	1.4
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.4529-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4529-.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+ combinedbcm, bcm_target,	55,	1e6,	g,	1.4
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.4532.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4532.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_dg_ds,	55,	1e6,	g,	1.4
+ combinedbcm, bcm_target,	55,	1e6,	g,	1.4
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.4872-.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4872-.map
@@ -37,7 +37,7 @@ EVENTCUTS = 3
 !(QwVQWK_Channel::fHardwareBlockSum)
 
 !device_type, device_name, lower_limit, upper_limit, local(l)/global(g), stability_RMS, burplevel
- bcm,	bcm_dg_ds,	70,	1e6,	g,	1.7
+ combinedbcm, bcm_target,	70,	1e6,	g,	1.7
 
 
 

--- a/Parity/prminput/prexCH_beamline_eventcuts.4940-4970.map
+++ b/Parity/prminput/prexCH_beamline_eventcuts.4940-4970.map
@@ -29,7 +29,7 @@ EVENTCUTS = 3
 !device_type, device_name,      lower limit, upper limit, local(l)/global(g), stability RMS, burplevel
 ! 70 uA running BCM, BPM tracking non-saturation, global promotion of device error codes
  bcm, bcm_an_us,		1,	1e6,	l 
- bcm, bcm_dg_ds,		1,	1e6,	g,	0
+ combinedbcm, bcm_target,		1,	1e6,	g,	0
  bpmstripline, bpm4a, xm, 1000, 55000, g, 0, 1000
  bpmstripline, bpm4a, xp, 1000, 55000, g, 0, 1000
  bpmstripline, bpm4a, ym, 1000, 55000, g, 0, 1000


### PR DESCRIPTION
The global BCM cuts (which are used to form the beam trip cuts) have
been changed to use the combined BCM variable "bcm_target" for the
entire PREX2 running period.  This variable is usually defined to be
(2*bcm_an_us + bcm_an_ds)/3, except for the periods where the analog
BCMs were not working, when it is instead defined to be bcm_dg_ds.