### PR TITLE
Adding the "BMW extractor" to the standard PREX/CREX data handler arrays

### DIFF
--- a/Parity/prminput/prex_datahandlers.2948-2962.map
+++ b/Parity/prminput/prex_datahandlers.2948-2962.map
@@ -33,13 +33,6 @@
   tree-name  = lrb_std
   tree-comment = Correlations
 
-[QwExtractor]
-  name       = bmw
-  priority   = 50
-  map        = prex_bmw.conf
-  tree-name  = bmw
-  tree-comment = Beam modulation
-
 #[QwCorrelator]
 #  name       = lrb_all
 #  priority   = 50
@@ -59,3 +52,11 @@
   map        = prex_combiner.map
   tree-name  = mulc
   tree-comment = Helicity event data tree (corrected)
+
+[QwExtractor]
+  name       = BMWExtractor
+  priority   = 0
+  scope      = event
+  tree-name  = bmw          # not implemented at this time, currently hardcoded
+  tree-comment = Bmod Data  # not implemented at this time, currently hardcoded
+

--- a/Parity/prminput/prex_datahandlers.3130-4980.map
+++ b/Parity/prminput/prex_datahandlers.3130-4980.map
@@ -186,3 +186,11 @@
   tree-name  = lrb_all
   tree-comment = Correlations (all variables)
 
+
+[QwExtractor]
+  name       = BMWExtractor
+  priority   = 0
+  scope      = event
+  tree-name  = bmw          # not implemented at this time, currently hardcoded
+  tree-comment = Bmod Data  # not implemented at this time, currently hardcoded
+

--- a/Parity/prminput/prex_datahandlers.5140-.map
+++ b/Parity/prminput/prex_datahandlers.5140-.map
@@ -92,3 +92,11 @@
   map        = prex_combiner.map
   tree-name  = mulc
   tree-comment = Helicity event data tree (corrected)
+
+[QwExtractor]
+  name       = BMWExtractor
+  priority   = 0
+  scope      = event
+  tree-name  = bmw          # not implemented at this time, currently hardcoded
+  tree-comment = Bmod Data  # not implemented at this time, currently hardcoded
+


### PR DESCRIPTION
The "BMW extractor" had not been included in the standard data hanlder configurations
for much of the PREX and CREX run periods.  It had been present in the last portion
of the CREX run period already.