### PR TITLE
Cut one event in each of runs 4512 and 4519.

### DIFF
--- a/Parity/prminput/prex_bad_events.4512.map
+++ b/Parity/prminput/prex_bad_events.4512.map
@@ -1,0 +1,2 @@
+#  BCM_AN_US glitch
+418638

--- a/Parity/prminput/prex_bad_events.4519.map
+++ b/Parity/prminput/prex_bad_events.4519.map
@@ -1,0 +1,2 @@
+#  BCM_AN_US glitch
+247145


### PR DESCRIPTION
One event in each of runs 4512 and 4519 has the analog US bcm signal
glitch low by about 20uA.  The DS analog bcm remains in agreement with
the two digital bcm signals for these two events.
These events have been marked as bad.