### PR TITLE
Bugfix: avoid evio narrowing warning/error on gcc-10 (after #313)

### DIFF
--- a/Analysis/src/QwOptions.cc
+++ b/Analysis/src/QwOptions.cc
@@ -20,7 +20,7 @@
 #include <iostream>
 #include <fstream>
 #include <cstdlib>
-
+#include <TROOT.h>
 // Qweak headers
 #include "QwLog.h"
 #include "QwParameterFile.h"

--- a/Parity/include/QwBlinder.h
+++ b/Parity/include/QwBlinder.h
@@ -16,6 +16,7 @@
 
 // ROOT headers
 #include <TString.h>
+#include <TObjString.h>
 #include <TMD5.h>
 
 // Qweak headers

--- a/Parity/src/LRBCorrector.cc
+++ b/Parity/src/LRBCorrector.cc
@@ -30,8 +30,8 @@ Last Modified: August 1, 2018 1:41 PM
 
 #include <TFile.h>
 #include <TH2.h>
+#include <TKey.h>
 #include <TTree.h> 
-
 #include <TChain.h>
 #include <TObjArray.h>
 #include <TEventList.h> 

--- a/evio/include/THaCodaFile.h
+++ b/evio/include/THaCodaFile.h
@@ -52,7 +52,7 @@ private:
   THaCodaFile& operator=(const THaCodaFile &fn);
   void init(TString fname);
   void initFilter();
-  void staterr(TString tried_to, int status);  // Can cause job to exit(0)
+  void staterr(TString tried_to, unsigned int status);  // Can cause job to exit(0)
   int ffirst;
   int max_to_filt;
   EVFILE *handle;

--- a/evio/src/THaCodaFile.C
+++ b/evio/src/THaCodaFile.C
@@ -252,7 +252,7 @@ Finish:
 
 
 
-void THaCodaFile::staterr(TString tried_to, int status) {
+void THaCodaFile::staterr(TString tried_to, unsigned int status) {
 // staterr gives the non-expert user a reasonable clue
 // of what the status returns from evio mean.
 // Note: severe errors can cause job to exit(0)


### PR DESCRIPTION
`0x80730001` is an unsigned int. Comparing to an int requires conversion to an int, which narrows the domain. In this case, `staterr` is a harmless function that only provides helpful warning messages. We change the status variable into an unsigned int so that the conversion is made explicit in the call to `staterr`.

```
[  1%] Building CXX object evio/CMakeFiles/evio.dir/src/THaCodaFile.C.o
cd /home/wdconinc/git/japan/build/evio && /usr/bin/c++  -Devio_EXPORTS -I/home/wdconinc/git/japan/evio/include -I/home/wdconinc/git/japan/build/evio -isystem /usr/local/root/pro/include  -O2 -g -DNDEBUG -fno-omit-frame-pointer -fPIC   -pipe -fsigned-char -mtune=generic -pthread -std=c++17 -m64 -Wall -o CMakeFiles/evio.dir/src/THaCodaFile.C.o -c /home/wdconinc/git/japan/evio/src/THaCodaFile.C
In file included from /home/wdconinc/git/japan/evio/include/THaCodaFile.h:23,
                 from /home/wdconinc/git/japan/evio/src/THaCodaFile.C:17:
/home/wdconinc/git/japan/evio/src/THaCodaFile.C: In member function ‘void THaCodaFile::staterr(TString, int)’:
/home/wdconinc/git/japan/evio/include/evio.h:16:31: error: narrowing conversion of ‘2155020289’ from ‘unsigned int’ to ‘int’ [-Wnarrowing]
   16 | #define S_EVFILE_BADHANDLE    0x80730001      /* Bad handle (file/stream not open) */
      |                               ^~~~~~~~~~
/home/wdconinc/git/japan/evio/src/THaCodaFile.C:276:12: note: in expansion of macro ‘S_EVFILE_BADHANDLE’
  276 |       case S_EVFILE_BADHANDLE :
      |            ^~~~~~~~~~~~~~~~~~
/home/wdconinc/git/japan/evio/include/evio.h:17:31: error: narrowing conversion of ‘2155020290’ from ‘unsigned int’ to ‘int’ [-Wnarrowing]
   17 | #define S_EVFILE_ALLOCFAIL    0x80730002      /* Failed to allocate event I/O structure */
      |                               ^~~~~~~~~~
/home/wdconinc/git/japan/evio/src/THaCodaFile.C:279:12: note: in expansion of macro ‘S_EVFILE_ALLOCFAIL’
  279 |       case S_EVFILE_ALLOCFAIL :
      |            ^~~~~~~~~~~~~~~~~~
/home/wdconinc/git/japan/evio/include/evio.h:18:31: error: narrowing conversion of ‘2155020291’ from ‘unsigned int’ to ‘int’ [-Wnarrowing]
   18 | #define S_EVFILE_BADFILE      0x80730003      /* File format error */
      |                               ^~~~~~~~~~
/home/wdconinc/git/japan/evio/src/THaCodaFile.C:282:12: note: in expansion of macro ‘S_EVFILE_BADFILE’
  282 |       case S_EVFILE_BADFILE :
      |            ^~~~~~~~~~~~~~~~
/home/wdconinc/git/japan/evio/include/evio.h:19:31: error: narrowing conversion of ‘2155020292’ from ‘unsigned int’ to ‘int’ [-Wnarrowing]
   19 | #define S_EVFILE_UNKOPTION    0x80730004      /* Unknown option specified */
      |                               ^~~~~~~~~~
/home/wdconinc/git/japan/evio/src/THaCodaFile.C:285:12: note: in expansion of macro ‘S_EVFILE_UNKOPTION’
  285 |       case S_EVFILE_UNKOPTION :
      |            ^~~~~~~~~~~~~~~~~~
/home/wdconinc/git/japan/evio/include/evio.h:20:31: error: narrowing conversion of ‘2155020293’ from ‘unsigned int’ to ‘int’ [-Wnarrowing]
   20 | #define S_EVFILE_UNXPTDEOF    0x80730005      /* Unexpected end of file while reading event */
      |                               ^~~~~~~~~~
/home/wdconinc/git/japan/evio/src/THaCodaFile.C:288:12: note: in expansion of macro ‘S_EVFILE_UNXPTDEOF’
  288 |       case S_EVFILE_UNXPTDEOF :
      |            ^~~~~~~~~~~~~~~~~~
make[2]: *** [evio/CMakeFiles/evio.dir/build.make:92: evio/CMakeFiles/evio.dir/src/THaCodaFile.C.o] Error 1
make[2]: Leaving directory '/home/wdconinc/git/japan/build'
make[1]: *** [CMakeFiles/Makefile2:318: evio/CMakeFiles/evio.dir/all] Error 2
make[1]: Leaving directory '/home/wdconinc/git/japan/build'
make: *** [Makefile:130: all] Error 2
make: Leaving directory '/home/wdconinc/git/japan/build'
```