### PR TITLE
Adding include of TString.h needed to compile with ROOT newer than 6.20.

### DIFF
--- a/Parity/src/LinReg_Bevington_Pebay.cc
+++ b/Parity/src/LinReg_Bevington_Pebay.cc
@@ -11,6 +11,8 @@
 #include <assert.h>
 #include <math.h>
 
+#include "TString.h"
+
 #include "LinReg_Bevington_Pebay.h"
 
 #include "QwLog.h"


### PR DESCRIPTION
This has been test compiled with ROOT 6.24.00  and g++ 7.5.0 on Ubuntu 18.04.5