### PR TITLE
Fix compilation on macOS (and probably on other platforms too)

### DIFF
--- a/Parity/include/QwBPMCavity.h
+++ b/Parity/include/QwBPMCavity.h
@@ -18,6 +18,7 @@
 #include "QwVQWK_Channel.h"
 #include "VQwBPM.h"
 #include "QwParameterFile.h"
+#include "QwUtil.h"
 
 // Forward declarations
 class QwDBInterface;
@@ -49,9 +50,12 @@ class QwBPMCavity : public VQwBPM {
 	  InitializeChannel(subsystemname, name);
   };
   QwBPMCavity(const QwBPMCavity& source)
-  : VQwBPM(source),
-    fElement(source.fElement),fRelPos(source.fRelPos),fAbsPos(source.fAbsPos)
-  { }
+  : VQwBPM(source)
+  {
+    QwCopyArray(source.fElement, fElement);
+    QwCopyArray(source.fRelPos, fRelPos);
+    QwCopyArray(source.fAbsPos, fAbsPos);
+  }
   virtual ~QwBPMCavity() { };
 
   void    InitializeChannel(TString name);

--- a/Parity/include/QwBPMStripline.h
+++ b/Parity/include/QwBPMStripline.h
@@ -17,6 +17,7 @@
 // Qweak headers
 #include "VQwBPM.h"
 #include "QwParameterFile.h"
+#include "QwUtil.h"
 
 // Forward declarations
 #ifdef __USE_DATABASE__
@@ -38,7 +39,7 @@ class QwBPMStripline : public VQwBPM {
 
  public:
   static UInt_t  GetSubElementIndex(TString subname);
-  
+
  public:
   QwBPMStripline() { };
   QwBPMStripline(TString name) {
@@ -46,26 +47,29 @@ class QwBPMStripline : public VQwBPM {
     fRotationAngle = 45.0;
     SetRotation(fRotationAngle);
     bRotated=kTRUE;
-  };   
+  };
   QwBPMStripline(TString subsystemname, TString name) {
     SetSubsystemName(subsystemname);
     InitializeChannel(subsystemname, name);
     fRotationAngle = 45.0;
     SetRotation(fRotationAngle);
     bRotated=kTRUE;
-  };    
+  };
   QwBPMStripline(TString subsystemname, TString name, TString type) {
     SetSubsystemName(subsystemname);
     InitializeChannel(subsystemname, name, type);
     fRotationAngle = 45.0;
     SetRotation(fRotationAngle);
     bRotated=kTRUE;
-  };    
+  };
   QwBPMStripline(const QwBPMStripline& source)
   : VQwBPM(source),
-    fWire(source.fWire),fRelPos(source.fRelPos),fAbsPos(source.fAbsPos),
     fEffectiveCharge(source.fEffectiveCharge),fEllipticity(source.fEllipticity)
-  { }
+  {
+    QwCopyArray(source.fWire, fWire);
+    QwCopyArray(source.fRelPos, fRelPos);
+    QwCopyArray(source.fAbsPos, fAbsPos);
+  }
   virtual ~QwBPMStripline() { };
 
   void    InitializeChannel(TString name);
@@ -199,7 +203,7 @@ class QwBPMStripline : public VQwBPM {
   T fEffectiveCharge;
   T fEllipticity;
 
-private: 
+private:
   // Functions to be removed
   void    SetEventData(Double_t* block, UInt_t sequencenumber);
   std::vector<T> fBPMElementList;

--- a/Parity/include/QwCombinedBPM.h
+++ b/Parity/include/QwCombinedBPM.h
@@ -17,6 +17,7 @@
 // Qweak headers
 #include "VQwHardwareChannel.h"
 #include "VQwBPM.h"
+#include "QwUtil.h"
 
 // Forward declarations
 #ifdef __USE_DATABASE__
@@ -39,7 +40,7 @@ class QwCombinedBPM : public VQwBPM {
 //-------------------------------------------------------------------------
   size_t GetNumberOfElements() {return fElement.size();};
   TString GetSubElementName(Int_t index) {return fElement.at(index)->GetElementName();};
-//-------------------------------------------------------------------------  
+//-------------------------------------------------------------------------
 
   QwCombinedBPM(){
   };
@@ -55,12 +56,13 @@ class QwCombinedBPM : public VQwBPM {
   };
   QwCombinedBPM(const QwCombinedBPM& source)
   : VQwBPM(source),
-    fSlope(source.fSlope),
-    fIntercept(source.fIntercept),
-    fMinimumChiSquare(source.fMinimumChiSquare),
-    fAbsPos(source.fAbsPos),
     fEffectiveCharge(source.fEffectiveCharge)
-  { }
+  {
+    QwCopyArray(source.fSlope, fSlope);
+    QwCopyArray(source.fIntercept, fIntercept);
+    QwCopyArray(source.fMinimumChiSquare, fMinimumChiSquare);
+    QwCopyArray(source.fAbsPos, fAbsPos);
+  }
   virtual ~QwCombinedBPM() { };
 
   using VQwBPM::EBeamPositionMonitorAxis;
@@ -184,7 +186,7 @@ class QwCombinedBPM : public VQwBPM {
   Double_t SumOver( std::vector <Double_t> weight , std::vector <T> val);
   void     LeastSquareFit(VQwBPM::EBeamPositionMonitorAxis axis, std::vector<Double_t> fWeights) ; //bbbbb
 
-  
+
 
   /////
  private:
@@ -217,7 +219,7 @@ class QwCombinedBPM : public VQwBPM {
   T fAbsPos[2];
   T fEffectiveCharge;
 
-private: 
+private:
   // Functions to be removed
   void    MakeBPMComboList();
   std::vector<T> fBPMComboElementList;
@@ -227,4 +229,3 @@ private:
 
 
 #endif
-

--- a/Parity/include/QwQPD.h
+++ b/Parity/include/QwQPD.h
@@ -18,6 +18,7 @@
 #include "QwVQWK_Channel.h"
 #include "VQwBPM.h"
 #include "QwParameterFile.h"
+#include "QwUtil.h"
 
 // Forward declarations
 #ifdef __USE_DATABASE__
@@ -46,16 +47,17 @@ class QwQPD : public VQwBPM {
     InitializeChannel(subsystemname, name);
     fQwQPDCalibration[0] = 1.0;
     fQwQPDCalibration[1] = 1.0;
-  };    
+  };
   QwQPD(const QwQPD& source)
   : VQwBPM(source),
-    fPhotodiode(source.fPhotodiode),
-    fRelPos(source.fRelPos),
-    fAbsPos(source.fAbsPos),
     fEffectiveCharge(source.fEffectiveCharge)
-  { }
+  {
+    QwCopyArray(source.fPhotodiode, fPhotodiode);
+    QwCopyArray(source.fRelPos, fRelPos);
+    QwCopyArray(source.fAbsPos, fAbsPos);
+  }
   virtual ~QwQPD() { };
-  
+
   void    InitializeChannel(TString name);
   // new routine added to update necessary information for tree trimming
   void    InitializeChannel(TString subsystem, TString name);
@@ -66,7 +68,7 @@ class QwQPD : public VQwBPM {
   }
 
   void    GetCalibrationFactors(Double_t AlphaX, Double_t AlphaY);
-  
+
   void    ClearEventData();
   Int_t   ProcessEvBuffer(UInt_t* buffer,
 			UInt_t word_position_in_buffer,UInt_t indexnumber);
@@ -149,7 +151,7 @@ class QwQPD : public VQwBPM {
  private:
 
 
-  static const TString subelement[4]; 
+  static const TString subelement[4];
   /*  Position calibration factor, transform ADC counts in mm */
   Double_t fQwQPDCalibration[2];
 

--- a/Parity/include/QwUtil.h
+++ b/Parity/include/QwUtil.h
@@ -1,0 +1,16 @@
+// Helper functions
+//
+// Created by Ole Hansen on 8/16/23.
+//
+
+#ifndef QWANALYSIS_QWUTIL_H
+#define QWANALYSIS_QWUTIL_H
+
+#include <algorithm>
+#include <iterator>
+
+// Copy C-style array a to b
+#define QwCopyArray(a,b) \
+  std::copy(std::begin(a), std::end(a), std::begin(b))
+
+#endif //QWANALYSIS_QWUTIL_H

--- a/Parity/include/QwUtil.h
+++ b/Parity/include/QwUtil.h
@@ -10,7 +10,9 @@
 #include <iterator>
 
 // Copy C-style array a to b
-#define QwCopyArray(a,b) \
-  std::copy(std::begin(a), std::end(a), std::begin(b))
+template<typename T>
+void QwCopyArray( const T& a, T& b ) {
+  std::copy(std::begin(a), std::end(a), std::begin(b));
+}
 
 #endif //QWANALYSIS_QWUTIL_H

--- a/evio/src/THaCodaFile.C
+++ b/evio/src/THaCodaFile.C
@@ -22,7 +22,7 @@ ClassImp(THaCodaFile)
 #endif
 #endif
 
-//Constructors 
+//Constructors
 
   THaCodaFile::THaCodaFile() {       // do nothing (must open file separately)
        ffirst = 0;
@@ -31,7 +31,7 @@ ClassImp(THaCodaFile)
   THaCodaFile::THaCodaFile(TString fname) {
        ffirst = 0;
        init(fname);
-       codaOpen(fname.Data(),"r");       // read only 
+       codaOpen(fname.Data(),"r");       // read only
   }
   THaCodaFile::THaCodaFile(TString fname, TString readwrite) {
        ffirst = 0;
@@ -43,9 +43,9 @@ ClassImp(THaCodaFile)
   THaCodaFile::~THaCodaFile () {
        codaClose();
        staterr("close",fStatus);
-  };       
+  };
 
-  int THaCodaFile::codaOpen(TString fname) {  
+  int THaCodaFile::codaOpen(TString fname) {
        init(fname);
        char rw[] ="r";
        // Introduce "char rw[]" to suppress  "warning: deprecated conversion from string constant to 'char*'"
@@ -55,7 +55,7 @@ ClassImp(THaCodaFile)
        return fStatus;
   };
 
-  int THaCodaFile::codaOpen(TString fname, TString readwrite) {  
+  int THaCodaFile::codaOpen(TString fname, TString readwrite) {
       init(fname);
       fStatus = evOpen((char*)fname.Data(),(char*)readwrite.Data(),&handle);
       staterr("open",fStatus);
@@ -120,8 +120,8 @@ ClassImp(THaCodaFile)
 
   int THaCodaFile::filterToFile(TString output_file) {
 // A call to filterToFile filters from present file to output_file
-// using filter criteria defined by evtypes, evlist, and max_to_filt 
-// which are loaded by public methods of this class.  If no conditions 
+// using filter criteria defined by evtypes, evlist, and max_to_filt
+// which are loaded by public methods of this class.  If no conditions
 // were loaded, it makes a copy of the input file (i.e. no filtering).
 
        int i;
@@ -144,7 +144,7 @@ ClassImp(THaCodaFile)
           fclose(fp);
           return CODA_ERROR;
        }
-       THaCodaFile* fout = new THaCodaFile(output_file.Data(),"w"); 
+       THaCodaFile* fout = new THaCodaFile(output_file.Data(),"w");
        int nfilt = 0;
 
        while (codaRead() == S_SUCCESS) {
@@ -152,16 +152,16 @@ ClassImp(THaCodaFile)
            int evtype = rawbuff[1]>>16;
            int evnum = rawbuff[4];
            int oktofilt = 1;
-           if (CODA_DEBUG) { 
+           if (CODA_DEBUG) {
 	     std::cout << "Input evtype " << std::dec << evtype;
-             std::cout << "  evnum " << evnum << std::endl; 
+             std::cout << "  evnum " << evnum << std::endl;
              std::cout << "max_to_filt = " << max_to_filt << std::endl;
              std::cout << "evtype size = " << evtypes[0] << std::endl;
              std::cout << "evlist size = " << evlist[0] << std::endl;
 	   }
            if ( evtypes[0] > 0 ) {
                oktofilt = 0;
-               for (i=1; i<=evtypes[0]; i++) {               
+               for (i=1; i<=evtypes[0]; i++) {
                    if (evtype == evtypes[i]) {
                        oktofilt = 1;
                        goto Cont1;
@@ -171,7 +171,7 @@ ClassImp(THaCodaFile)
 Cont1:
            if ( evlist[0] > 0 ) {
                oktofilt = 0;
-               for (i=1; i<=evlist[0]; i++) {               
+               for (i=1; i<=evlist[0]; i++) {
                    if (evnum == evlist[i]) {
                        oktofilt = 1;
                        goto Cont2;
@@ -264,19 +264,19 @@ void THaCodaFile::staterr(TString tried_to, unsigned int status) {
        std::cout << "   1.  You mistyped the name of file ?" << std::endl;
        std::cout << "   2.  The file has length zero ? " << std::endl;
     }
-    switch (status) {
+    switch (static_cast<Long64_t>(status)) {
       case S_EVFILE_TRUNC :
 	 std::cout << "THaCodaFile ERROR:  Truncated event on file read" << std::endl;
          std::cout << "Evbuffer size is too small.  Job aborted." << std::endl;
          exit(0);  //  If this ever happens, recompile with MAXEVLEN
-	           //  bigger, and mutter under your breath at the author.    
-      case S_EVFILE_BADBLOCK : 
+	           //  bigger, and mutter under your breath at the author.
+      case S_EVFILE_BADBLOCK :
         std::cout << "Bad block number encountered " << std::endl;
         break;
       case S_EVFILE_BADHANDLE :
         std::cout << "Bad handle (file/stream not open) " << std::endl;
         break;
-      case S_EVFILE_ALLOCFAIL : 
+      case S_EVFILE_ALLOCFAIL :
         std::cout << "Failed to allocate event I/O" << std::endl;
         break;
       case S_EVFILE_BADFILE :
@@ -288,7 +288,7 @@ void THaCodaFile::staterr(TString tried_to, unsigned int status) {
       case S_EVFILE_UNXPTDEOF :
         std::cout << "Unexpected end of file while reading event" << std::endl;
         break;
-      case EOF: 
+      case EOF:
         if(CODA_VERBOSE) {
           std::cout << "Normal end of file " << filename << " encountered" << std::endl;
 	}
@@ -314,15 +314,3 @@ void THaCodaFile::staterr(TString tried_to, unsigned int status) {
        evtypes[0] = 0;
     }
   };
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
- THaCodaFile switch variable was out of range
- Several constructors attempted direct initialization of C-style arrays, array(other.array), which is ill-formed C++. (How did this ever work?)

Fixes JeffersonLab/japan#2